### PR TITLE
Update restoration_simulation to avoid mixed integers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/site/
 docs/.documenter
 .project
 .tags
+Manifest.toml

--- a/docs/src/prob.md
+++ b/docs/src/prob.md
@@ -8,7 +8,7 @@ run_rop_uc
 ```
 # Shared Functions
 ```@docs
-solution_rop
+solution_rop!
 ```
 
 # All functions

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -251,9 +251,16 @@ function constraint_storage_damage(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=
 end
 
 ""
-function constraint_bus_damage(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function constraint_bus_voltage_violation_damage(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     bus = _PMs.ref(pm, nw, :bus, i)
 
-    constraint_bus_damage(pm, nw, cnd, i, bus["vmin"], bus["vmax"])
+    constraint_bus_voltage_violation_damage(pm, nw, cnd, i, bus["vmin"], bus["vmax"])
+end
+
+""
+function constraint_bus_voltage_violation(pm::_PMs.AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    bus = _PMs.ref(pm, nw, :bus, i)
+
+    constraint_bus_voltage_violation(pm, nw, cnd, i, bus["vmin"], bus["vmax"])
 end
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -10,7 +10,7 @@ function variable_voltage_damage(pm::_PMs.AbstractACPModel; kwargs...)
 end
 
 ""
-function constraint_bus_damage(pm::_PMs.AbstractACPModel, n::Int, c::Int, i::Int, vm_min, vm_max)
+function constraint_bus_voltage_violation_damage(pm::_PMs.AbstractACPModel, n::Int, c::Int, i::Int, vm_min, vm_max)
     vm = _PMs.var(pm, n, c, :vm, i)
     vm_vio = _PMs.var(pm, n, c, :vm_vio, i)
     z = _PMs.var(pm, n, :z_bus, i)
@@ -18,3 +18,13 @@ function constraint_bus_damage(pm::_PMs.AbstractACPModel, n::Int, c::Int, i::Int
     JuMP.@constraint(pm.model, vm <= z*vm_max)
     JuMP.@constraint(pm.model, vm >= z*vm_min - vm_vio)
 end
+
+""
+function constraint_bus_voltage_violation(pm::_PMs.AbstractACPModel, n::Int, c::Int, i::Int, vm_min, vm_max)
+    vm = _PMs.var(pm, n, c, :vm, i)
+    vm_vio = _PMs.var(pm, n, c, :vm_vio, i)
+
+    JuMP.@constraint(pm.model, vm <= vm_max)
+    JuMP.@constraint(pm.model, vm >= vm_min - vm_vio)
+end
+

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -7,5 +7,9 @@ function variable_voltage_damage(pm::_PMs.AbstractDCPModel; kwargs...)
 end
 
 "no vm values to turn off"
-function constraint_bus_damage(pm::_PMs.AbstractDCPModel, n::Int, c::Int, i::Int, vm_min, vm_max)
+function constraint_bus_voltage_violation_damage(pm::_PMs.AbstractDCPModel, n::Int, c::Int, i::Int, vm_min, vm_max)
+end
+
+"no vm values to turn off"
+function constraint_bus_voltage_violation(pm::_PMs.AbstractDCPModel, n::Int, c::Int, i::Int, vm_min, vm_max)
 end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -118,7 +118,7 @@ end
 
 
 ""
-function constraint_bus_damage(pm::_PMs.AbstractWRModel, n::Int, c::Int, i::Int, vm_min, vm_max)
+function constraint_bus_voltage_violation_damage(pm::_PMs.AbstractWRModel, n::Int, c::Int, i::Int, vm_min, vm_max)
     w = _PMs.var(pm, n, c, :w, i)
     w_vio = _PMs.var(pm, n, c, :w_vio, i)
     z = _PMs.var(pm, n, :z_bus, i)
@@ -127,6 +127,14 @@ function constraint_bus_damage(pm::_PMs.AbstractWRModel, n::Int, c::Int, i::Int,
     JuMP.@constraint(pm.model, w >= z*vm_min^2 - w_vio)
 end
 
+""
+function constraint_bus_voltage_violation(pm::_PMs.AbstractWRModel, n::Int, c::Int, i::Int, vm_min, vm_max)
+    w = _PMs.var(pm, n, c, :w, i)
+    w_vio = _PMs.var(pm, n, c, :w_vio, i)
+
+    JuMP.@constraint(pm.model, w <= vm_max^2)
+    JuMP.@constraint(pm.model, w >= vm_min^2 - w_vio)
+end
 
 "`p[arc_from]^2 + q[arc_from]^2 <= w[f_bus]/tm*ccm[i]`"
 function _PMs.constraint_power_magnitude_sqr_on_off(pm::_PMs.AbstractQCWRModel, n::Int, c::Int, i, f_bus, arc_from, tm)

--- a/src/prob/mrsp.jl
+++ b/src/prob/mrsp.jl
@@ -2,7 +2,7 @@
 function run_mrsp(file, model_constructor, optimizer; kwargs...)
     return _PMs.run_model(file, model_constructor, optimizer, post_mrsp;
         ref_extensions=[_PMs.ref_add_on_off_va_bounds!, ref_add_damaged_items!],
-        solution_builder = solution_mrsp, kwargs...)
+        solution_builder = solution_mrsp!, kwargs...)
 end
 
 
@@ -29,7 +29,7 @@ function post_mrsp(pm::_PMs.AbstractPowerModel)
     end
 
     for i in _PMs.ids(pm, :bus)
-        constraint_bus_damage(pm, i)
+        constraint_bus_voltage_violation_damage(pm, i)
         _PMs.constraint_power_balance(pm, i)
     end
 
@@ -81,7 +81,7 @@ end
 
 
 "report minimal restoration set solution"
-function solution_mrsp(pm::_PMs.AbstractPowerModel, sol::Dict{String,Any})
+function solution_mrsp!(pm::_PMs.AbstractPowerModel, sol::Dict{String,Any})
     add_setpoint_bus_status!(sol,pm)
     _PMs.add_setpoint_bus_voltage!(sol, pm)
     _PMs.add_setpoint_generator_status!(sol, pm)

--- a/src/prob/rop.jl
+++ b/src/prob/rop.jl
@@ -2,7 +2,7 @@
 function run_rop(file, model_constructor, optimizer; kwargs...)
     return _PMs.run_model(file, model_constructor, optimizer, post_rop; multinetwork=true,
         ref_extensions=[_PMs.ref_add_on_off_va_bounds!, ref_add_damaged_items!],
-        solution_builder = solution_rop, kwargs...)
+        solution_builder = solution_rop!, kwargs...)
 end
 
 
@@ -35,7 +35,7 @@ function post_rop(pm::_PMs.AbstractPowerModel)
         end
 
         for i in _PMs.ids(pm, :bus, nw=n)
-            constraint_bus_damage(pm, i, nw=n)
+            constraint_bus_voltage_violation_damage(pm, i, nw=n)
             _MLD.constraint_power_balance_shed(pm, i, nw=n)
         end
 
@@ -110,8 +110,9 @@ end
 
 
 "report restoration solution"
-function solution_rop(pm::_PMs.AbstractPowerModel, sol::Dict{String,Any})
+function solution_rop!(pm::_PMs.AbstractPowerModel, sol::Dict{String,Any})
     add_setpoint_bus_status!(sol,pm)
+    add_setpoint_bus_voltage_violation!(sol,pm)
     _PMs.add_setpoint_bus_voltage!(sol, pm)
     _PMs.add_setpoint_generator_status!(sol, pm)
     _PMs.add_setpoint_generator_power!(sol, pm)
@@ -126,6 +127,14 @@ end
 
 function add_setpoint_bus_status!(sol, pm::_PMs.AbstractPowerModel)
     _PMs.add_setpoint!(sol, pm, "bus", "status", :z_bus, status_name="bus_type", inactive_status_value = 4, conductorless=true, default_value = (item) -> if item["bus_type"] == 4 0 else 1 end)
+end
+
+function add_setpoint_bus_voltage_violation!(sol, pm::_PMs.AbstractPowerModel)
+    _PMs.add_setpoint!(sol, pm, "bus", "voltage_violation", :vm_vio)
+end
+
+function add_setpoint_bus_voltage_violation!(sol, pm::_PMs.AbstractWModels)
+    _PMs.add_setpoint!(sol, pm, "bus", "w_voltage_violation", :w_vio, status_name=_PMs.pm_component_status["bus"], inactive_status_value = _PMs.pm_component_status_inactive["bus"], scale = (x,item,cnd) -> sqrt(x))
 end
 
 # this is a slightly more numerically robust version of this for cases when :w is slightly negative due to numerical precision issues

--- a/src/util/restoration_simulation.jl
+++ b/src/util/restoration_simulation.jl
@@ -1,36 +1,3 @@
-# "Compute forward restoration of network_data"
-# function run_restoration_simulation(network_data, model_constructor, optimizer; kwargs...)
-#     _network_data = deepcopy(network_data)
-
-#     clean_status!(_network_data)
-#     net_id = map(x->parse(Int,x), sort(collect(keys(_network_data["nw"]))))
-
-#     for n in net_id
-#         network = _network_data["nw"]["$n"]
-#         network["per_unit"] = _network_data["per_unit"]
-
-#         result = _PMs.run_model(network, model_constructor, optimizer, _MLD.post_mld_strg; solution_builder=solution_rop, kwargs...)
-#         _network_data["nw"]["$n"]["solution"] = result
-#         network_forward = get(_network_data["nw"],"$(n+1)", Dict())
-
-#         # TODO is this the correct way to update storage energy?
-#         #=
-#         for (j, storage) in get(network_forward, "storage", Dict())
-#             energy = result["solution"]["storage"]["$j"]["se"]
-#             if !isnan(energy)
-#                 storage["energy"] = energy
-#             else # if network fails to solve, then set energy value to previous network's energy value
-#                 storage["energy"] = _network_data["nw"]["$(n-1)"]["storage"]["$j"]["energy"]
-#             end
-#         end
-#         =#
-
-#         active_power_served = sum(load["pd"] for (i,load) in result["solution"]["load"])
-#         Memento.warn(_PMs._LOGGER, "restoration step $(n), objective $(result["objective"]), active power $(active_power_served)")
-#     end
-
-#     return process_network(_network_data)
-# end
 
 "Simulate a restoration sequence power flow"
 function run_restoration_simulation(file::String, model_type::Type, optimizer; kwargs...)
@@ -41,66 +8,73 @@ end
 "Simulate a restoration sequence power flow"
 function run_restoration_simulation(data::Dict{String,Any}, model_type::Type, optimizer; kwargs...)
     clear_damage_indicator!(data)
-    return run_rop(data, model_type::Type, optimizer; kwargs...)
+    return _PMs.run_model(data, model_type, optimizer, post_restoration_simulation; multinetwork=true,
+    ref_extensions=[_PMs.ref_add_on_off_va_bounds!, ref_add_damaged_items!],
+    solution_builder = solution_rop!, kwargs...)
 end
 
-# ""
-# function post_restoration_simulation(pm::_PMs.AbstractPowerModel)
-#     for (n, network) in _PMs.nws(pm)
-#         _PMs.variable_voltage(pm, nw=n)
-#         _PMs.variable_generation(pm, nw=n)
-#         _PMs.variable_storage(pm, nw=n)
-#         _PMs.variable_branch_flow(pm, nw=n)
-#         _PMs.variable_dcline_flow(pm, nw=n)
+""
+function post_restoration_simulation(pm::_PMs.AbstractPowerModel)
+    for (n, network) in _PMs.nws(pm)
+        _PMs.variable_voltage(pm, nw=n)
+        variable_voltage_magnitude_violation(pm; nw=n)
 
-#         _PMs.constraint_model_voltage(pm, nw=n)
+        _PMs.variable_generation(pm, nw=n)
+        _PMs.variable_storage(pm, nw=n)
+        _PMs.variable_branch_flow(pm, nw=n)
+        _PMs.variable_dcline_flow(pm, nw=n)
 
-#         _MLD.variable_demand_factor(pm, nw=n, relax=true)
-#         _MLD.variable_shunt_factor(pm, nw=n, relax=true)
+        _MLD.variable_demand_factor(pm, nw=n, relax=true)
+        _MLD.variable_shunt_factor(pm, nw=n, relax=true)
 
-#         for i in _PMs.ids(pm, :ref_buses, nw=n)
-#             _PMs.constraint_theta_ref(pm, i, nw=n)
-#         end
+        _PMs.constraint_model_voltage(pm, nw=n)
 
-#         for i in _PMs.ids(pm, :bus, nw=n)
-#             _MLD.constraint_power_balance_shed(pm, i, nw=n)
-#         end
+        for i in _PMs.ids(pm, :ref_buses, nw=n)
+            _PMs.constraint_theta_ref(pm, i, nw=n)
+        end
 
-#         for i in _PMs.ids(pm, :storage, nw=n)
-#             _PMs.constraint_storage_complementarity_nl(pm, i, nw=n)
-#             _PMs.constraint_storage_loss(pm, i, nw=n)
-#             _PMs.constraint_storage_thermal_limit(pm, i, nw=n)
-#         end
+        for i in _PMs.ids(pm, :bus, nw=n)
+            constraint_bus_voltage_violation(pm, i, nw=n)
+            _MLD.constraint_power_balance_shed(pm, i, nw=n)
+        end
 
-#         for i in _PMs.ids(pm, :branch, nw=n)
-#             _PMs.constraint_ohms_yt_from(pm, i, nw=n)
-#             _PMs.constraint_ohms_yt_to(pm, i, nw=n)
+        for i in _PMs.ids(pm, :storage, nw=n)
+            _PMs.constraint_storage_complementarity_nl(pm, i, nw=n)
+            _PMs.constraint_storage_loss(pm, i, nw=n)
+            _PMs.constraint_storage_thermal_limit(pm, i, nw=n)
+        end
 
-#             _PMs.constraint_voltage_angle_difference_on_off(pm, i, nw=n)
+        for i in _PMs.ids(pm, :branch, nw=n)
+            _PMs.constraint_ohms_yt_from(pm, i, nw=n)
+            _PMs.constraint_ohms_yt_to(pm, i, nw=n)
 
-#             _PMs.constraint_thermal_limit_from(pm, i, nw=n)
-#             _PMs.constraint_thermal_limit_to(pm, i, nw=n)
-#         end
+            _PMs.constraint_voltage_angle_difference(pm, i, nw=n)
 
-#         for i in _PMs.ids(pm, :dcline, nw=n)
-#             _PMs.constraint_dcline(pm, i, nw=n)
-#         end
-#     end
+            _PMs.constraint_thermal_limit_from(pm, i, nw=n)
+            _PMs.constraint_thermal_limit_to(pm, i, nw=n)
+        end
 
-#     network_ids = sort(collect(_PMs.nw_ids(pm)))
+        for i in _PMs.ids(pm, :dcline, nw=n)
+            _PMs.constraint_dcline(pm, i, nw=n)
+        end
 
-#     n_1 = network_ids[1]
-#     for i in _PMs.ids(pm, :storage, nw=n_1)
-#         _PMs.constraint_storage_state(pm, i, nw=n_1)
-#     end
+    end
 
-#     for n_2 in network_ids[2:end]
-#         for i in _PMs.ids(pm, :storage, nw=n_2)
-#             _PMs.constraint_storage_state(pm, i, n_1, n_2)
-#         end
-#         n_1 = n_2
-#     end
+    network_ids = sort(collect(_PMs.nw_ids(pm)))
 
-#     objective_max_load_delivered(pm)
-# end
+    n_1 = network_ids[1]
+    for i in _PMs.ids(pm, :storage, nw=n_1)
+        _PMs.constraint_storage_state(pm, i, nw=n_1)
+    end
+
+    for n_2 in network_ids[2:end]
+        for i in _PMs.ids(pm, :storage, nw=n_2)
+            _PMs.constraint_storage_state(pm, i, n_1, n_2)
+        end
+        n_1 = n_2
+    end
+
+    objective_max_load_delivered(pm)
+
+end
 

--- a/test/restoration_simulation.jl
+++ b/test/restoration_simulation.jl
@@ -8,8 +8,8 @@
         result_rop = PowerModelsRestoration.run_rop(mn_data, PowerModels.ACPPowerModel, juniper_solver)
 
         PowerModelsRestoration.clean_solution!(result_rop)
-        PowerModels.update_data!(mn_data, result_rop["data"])
-        PowerModels.update_data!(mn_data, result_rop["solution"])
+        clean_status!(result_rop["solution"])
+        update_status!(mn_data, result_rop["solution"])
 
         result_sim = PowerModelsRestoration.run_restoration_simulation(mn_data, PowerModels.ACPPowerModel, ipopt_solver)
         @test result_sim["termination_status"] == LOCALLY_SOLVED
@@ -37,8 +37,8 @@
         result_rop = PowerModelsRestoration.run_rop(mn_data, PowerModels.DCPPowerModel, cbc_solver)
 
         PowerModelsRestoration.clean_solution!(result_rop)
-        PowerModels.update_data!(mn_data, result_rop["data"])
-        PowerModels.update_data!(mn_data, result_rop["solution"])
+        clean_status!(result_rop["solution"])
+        update_status!(mn_data, result_rop["solution"])
 
         result_sim = PowerModelsRestoration.run_restoration_simulation(mn_data, PowerModels.ACPPowerModel, ipopt_solver)
         @test result_sim["termination_status"] == LOCALLY_SOLVED
@@ -60,13 +60,13 @@
         @test isapprox(gen_power(result_sim, "1",["1","2","3","4","5"]), 9.87; atol=1)
     end
 
-    @testset "test ac simulation" begin
+    @testset "test soc simulation" begin
         mn_data = build_mn_data("../test/data/case5_restoration.m", replicates=2)
         result_rop = PowerModelsRestoration.run_rop(mn_data, PowerModels.SOCWRPowerModel, juniper_solver)
 
         PowerModelsRestoration.clean_solution!(result_rop)
-        PowerModels.update_data!(mn_data, result_rop["data"])
-        PowerModels.update_data!(mn_data, result_rop["solution"])
+        clean_status!(result_rop["solution"])
+        update_status!(mn_data, result_rop["solution"])
 
         result_sim = PowerModelsRestoration.run_restoration_simulation(mn_data, PowerModels.ACPPowerModel, ipopt_solver)
         @test result_sim["termination_status"] == LOCALLY_SOLVED


### PR DESCRIPTION
restoration_simulation used to remove the damage indicator and
use run_rop to redispatch the generation.  This process fixed the
restoration decisions and allowed the redispatch to use a solver
like Ipopt because the mixed integer variables are fixed. #19 

However, the complementary constraint on battery storage still used
a mixed integer.

This update creates a seperate subproblem for restoration simulation.
It is a multi-period opf that maxmizes load delivered, but can shed
load and allows (penalized) voltage violations.

Additional fixes:
added manifest.toml to. gitignore 

changed name of solution_rop to solution_rop! #18 

changed name of solution_mrsp to solution_mrsp! #18

added function for voltage violation on non-damaged buses
changed name of function constraint_bus_voltage to
constraint_bus_voltage_violation_damage to better represent
what the constraint does

changed _clean_status! to set status to the inactive value
if it is approximately that value, instead of rounding. This
prevents a load status of a sheddable load from being rounded
to status=0, and then being removed from the network when passed
to a subsequent problem (like simulation).

the test for restoration_simulation used update_data! instead of
update_status!.  This can cause errors where the reactive power of a
load is removed (set to NaN) by a DC power model for rop, then is
set to 0 when processed by  restoration_simulation. Instead, just the
status is updated from a solution to the network data for running
the simulation.

@ccoffrin 
@pseudocubic 