### PR TITLE
Name Updates for PowerModels v0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # PowerModelsRestoration.jl Change Log
 
 ## Staged
-- nothing
+- Update to new function name convention of PowerModels v0.17 (breaking)
+- Update to PowerModels v0.17 (breaking)
 
 ## v0.4.0
 - Update to PowerModels v0.16 (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # PowerModelsRestoration.jl Change Log
 
 ## Staged
-- Update to new function name convention of PowerModels v0.17 (breaking)
+- nothing
+
+## v0.5.0
+- Update to new function name convention of PowerModels v0.17 details in PR #40 (breaking)
 - Update to PowerModels v0.17 (breaking)
 
 ## v0.4.0

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 
 [compat]
-InfrastructureModels = "~0.4"
+InfrastructureModels = "~0.5"
 JuMP = "~0.19.1, ~0.20, ~0.21"
 MathOptInterface = "~0.8, ~0.9"
 Memento = "~0.10, ~0.11, ~0.12, ~0.13, ~1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerModelsRestoration"
 uuid = "23adbb12-a187-11e9-26a2-eb4d4e6e68fb"
 authors = ["David M Fobes <dfobes@lanl.gov>", "Noah Rhodes"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
@@ -15,7 +15,7 @@ InfrastructureModels = "~0.5"
 JuMP = "~0.19.1, ~0.20, ~0.21"
 MathOptInterface = "~0.8, ~0.9"
 Memento = "~0.10, ~0.11, ~0.12, ~0.13, ~1.0"
-PowerModels = "~0.16"
+PowerModels = "~0.17"
 julia = "^1"
 
 [extras]

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -63,7 +63,7 @@ end
 
 
 ""
-function constraint_gen_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_gen_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_gen), i)
         z_gen_1 = _PM.var(pm, nw_1, :z_gen, i)
         z_gen_2 = _PM.var(pm, nw_2, :z_gen, i)
@@ -73,7 +73,7 @@ function constraint_gen_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, n
 end
 
 ""
-function constraint_bus_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_bus_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_gen), i)
         z_bus_1 = _PM.var(pm, nw_1, :z_bus, i)
         z_bus_2 = _PM.var(pm, nw_2, :z_bus, i)
@@ -84,7 +84,7 @@ end
 
 
 ""
-function constraint_storage_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_storage_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_storage), i)
         z_storage_1 = _PM.var(pm, nw_1, :z_storage, i)
         z_storage_2 = _PM.var(pm, nw_2, :z_storage, i)
@@ -95,7 +95,7 @@ end
 
 
 ""
-function constraint_branch_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_branch_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_branch), i)
         z_branch_1 = _PM.var(pm, nw_1, :z_branch, i)
         z_branch_2 = _PM.var(pm, nw_2, :z_branch, i)

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -6,10 +6,10 @@ function constraint_restoration_cardinality_ub(pm::_PM.AbstractPowerModel, n::In
     z_bus = _PM.var(pm, n, :z_bus)
 
     JuMP.@constraint(pm.model,
-        sum(z_branch[i] for (i,branch) in _PM.ref(pm, n, :damaged_branch))
-        + sum(z_gen[i] for (i,gen) in _PM.ref(pm, n, :damaged_gen))
-        + sum(z_storage[i] for (i,storage) in _PM.ref(pm, n, :damaged_storage))
-        + sum(z_bus[i] for (i,bus) in _PM.ref(pm, n, :damaged_bus))
+        sum(z_branch[i] for (i,branch) in _PM.ref(pm, n, :branch_damage))
+        + sum(z_gen[i] for (i,gen) in _PM.ref(pm, n, :gen_damage))
+        + sum(z_storage[i] for (i,storage) in _PM.ref(pm, n, :storage_damage))
+        + sum(z_bus[i] for (i,bus) in _PM.ref(pm, n, :bus_damage))
         <= cumulative_repairs
     )
 end
@@ -23,10 +23,10 @@ function constraint_restoration_cardinality_lb(pm::_PM.AbstractPowerModel, n::In
     z_bus = _PM.var(pm, n, :z_bus)
 
     JuMP.@constraint(pm.model,
-        sum(z_branch[i] for (i,branch) in _PM.ref(pm, n, :damaged_branch))
-        + sum(z_gen[i] for (i,gen) in _PM.ref(pm, n, :damaged_gen))
-        + sum(z_storage[i] for (i,storage) in _PM.ref(pm, n, :damaged_storage))
-        + sum(z_bus[i] for (i,bus) in _PM.ref(pm, n, :damaged_bus))
+        sum(z_branch[i] for (i,branch) in _PM.ref(pm, n, :branch_damage))
+        + sum(z_gen[i] for (i,gen) in _PM.ref(pm, n, :gen_damage))
+        + sum(z_storage[i] for (i,storage) in _PM.ref(pm, n, :storage_damage))
+        + sum(z_bus[i] for (i,bus) in _PM.ref(pm, n, :bus_damage))
         >= cumulative_repairs
     )
 end
@@ -47,16 +47,16 @@ function constraint_restore_all_items(pm, n)
         JuMP.@constraint(pm.model, z_shunt[i] == 1)
     end
 
-    for (i,storage) in  _PM.ref(pm, n, :damaged_storage)
+    for (i,storage) in  _PM.ref(pm, n, :storage_damage)
         JuMP.@constraint(pm.model, z_storage[i] == 1)
     end
-    for (i,gen) in  _PM.ref(pm, n, :damaged_gen)
+    for (i,gen) in  _PM.ref(pm, n, :gen_damage)
         JuMP.@constraint(pm.model, z_gen[i] == 1)
     end
-    for (i,branch) in  _PM.ref(pm, n, :damaged_branch)
+    for (i,branch) in  _PM.ref(pm, n, :branch_damage)
         JuMP.@constraint(pm.model, z_branch[i] == 1)
     end
-    for (i,bus) in  _PM.ref(pm, n, :damaged_bus)
+    for (i,bus) in  _PM.ref(pm, n, :bus_damage)
         JuMP.@constraint(pm.model, z_bus[i] == 1)
     end
 end
@@ -64,7 +64,7 @@ end
 
 ""
 function constraint_gen_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
-    if haskey(_PM.ref(pm, nw_1, :damaged_gen), i)
+    if haskey(_PM.ref(pm, nw_1, :gen_damage), i)
         z_gen_1 = _PM.var(pm, nw_1, :z_gen, i)
         z_gen_2 = _PM.var(pm, nw_2, :z_gen, i)
 
@@ -74,7 +74,7 @@ end
 
 ""
 function constraint_bus_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
-    if haskey(_PM.ref(pm, nw_1, :damaged_gen), i)
+    if haskey(_PM.ref(pm, nw_1, :gen_damage), i)
         z_bus_1 = _PM.var(pm, nw_1, :z_bus, i)
         z_bus_2 = _PM.var(pm, nw_2, :z_bus, i)
 
@@ -85,7 +85,7 @@ end
 
 ""
 function constraint_storage_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
-    if haskey(_PM.ref(pm, nw_1, :damaged_storage), i)
+    if haskey(_PM.ref(pm, nw_1, :storage_damage), i)
         z_storage_1 = _PM.var(pm, nw_1, :z_storage, i)
         z_storage_2 = _PM.var(pm, nw_2, :z_storage, i)
 
@@ -96,7 +96,7 @@ end
 
 ""
 function constraint_branch_energized(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
-    if haskey(_PM.ref(pm, nw_1, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw_1, :branch_damage), i)
         z_branch_1 = _PM.var(pm, nw_1, :z_branch, i)
         z_branch_2 = _PM.var(pm, nw_2, :z_branch, i)
 

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -63,7 +63,7 @@ end
 
 
 ""
-function constraint_active_gen(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_gen_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_gen), i)
         z_gen_1 = _PM.var(pm, nw_1, :z_gen, i)
         z_gen_2 = _PM.var(pm, nw_2, :z_gen, i)
@@ -73,7 +73,7 @@ function constraint_active_gen(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, n
 end
 
 ""
-function constraint_active_bus(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_bus_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_gen), i)
         z_bus_1 = _PM.var(pm, nw_1, :z_bus, i)
         z_bus_2 = _PM.var(pm, nw_2, :z_bus, i)
@@ -84,7 +84,7 @@ end
 
 
 ""
-function constraint_active_storage(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_storage_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_storage), i)
         z_storage_1 = _PM.var(pm, nw_1, :z_storage, i)
         z_storage_2 = _PM.var(pm, nw_2, :z_storage, i)
@@ -95,7 +95,7 @@ end
 
 
 ""
-function constraint_active_branch(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_branch_active(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
     if haskey(_PM.ref(pm, nw_1, :damaged_branch), i)
         z_branch_1 = _PM.var(pm, nw_1, :z_branch, i)
         z_branch_2 = _PM.var(pm, nw_2, :z_branch, i)
@@ -106,7 +106,7 @@ end
 
 
 "Load delivered at each node must be greater than or equal the previous time period"
-function constraint_increasing_load(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
+function constraint_load_increasing(pm::_PM.AbstractPowerModel,  i::Int, nw_1::Int, nw_2::Int)
 
     z_demand_1 = _PM.var(pm, nw_1, :z_demand, i)
     z_demand_2 = _PM.var(pm, nw_2, :z_demand, i)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -25,8 +25,8 @@ end
 function constraint_gen_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     gen = _PM.ref(pm, nw, :gen, i)
 
-    gen_damaged = haskey(_PM.ref(pm, nw, :damaged_gen), i)
-    bus_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), gen["gen_bus"])
+    gen_damaged = haskey(_PM.ref(pm, nw, :gen_damage), i)
+    bus_damaged = haskey(_PM.ref(pm, nw, :bus_damage), gen["gen_bus"])
 
     if gen_damaged
         _PM.constraint_gen_power_on_off(pm, nw, i, gen["pmin"], gen["pmax"], gen["qmin"], gen["qmax"])
@@ -45,7 +45,7 @@ function constraint_load_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.c
     if haskey(_PM.ref(pm, nw, :load), i)
         load = _PM.ref(pm, nw, :load, i)
 
-        bus_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), load["load_bus"])
+        bus_damaged = haskey(_PM.ref(pm, nw, :bus_damage), load["load_bus"])
 
         if bus_damaged
             constraint_load_bus_connection(pm, nw, i, load["load_bus"])
@@ -58,7 +58,7 @@ end
 function constraint_shunt_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     if haskey(_PM.ref(pm, nw, :shunt), i)
         shunt = _PM.ref(pm, nw, :shunt, i)
-        bus_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), shunt["shunt_bus"])
+        bus_damaged = haskey(_PM.ref(pm, nw, :bus_damage), shunt["shunt_bus"])
 
         if bus_damaged
             constraint_shunt_bus_connection(pm, nw, i, shunt["shunt_bus"])
@@ -71,9 +71,9 @@ end
 function constraint_branch_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     branch = _PM.ref(pm, nw, :branch, i)
 
-    branch_damaged = haskey(_PM.ref(pm, nw, :damaged_branch), i)
-    bus_fr_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), branch["f_bus"])
-    bus_to_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), branch["t_bus"])
+    branch_damaged = haskey(_PM.ref(pm, nw, :branch_damage), i)
+    bus_fr_damaged = haskey(_PM.ref(pm, nw, :bus_damage), branch["f_bus"])
+    bus_to_damaged = haskey(_PM.ref(pm, nw, :bus_damage), branch["t_bus"])
 
     if branch_damaged
         if bus_fr_damaged
@@ -109,7 +109,7 @@ function constraint_ohms_yt_from_damage(pm::_PM.AbstractPowerModel, i::Int; nw::
     # TODO make indexing of :wi,:wr standardized
     ## Because :wi, :wr are indexed by bus_id or bus_pairs depending on if the value is on_off or
     # standard, there are indexing issues.  Temporary solution: always call *_on_off variant
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
         vad_min = _PM.ref(pm, nw, :off_angmin)
         vad_max = _PM.ref(pm, nw, :off_angmax)
         _PM.constraint_ohms_yt_from_on_off(pm, nw, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
@@ -139,7 +139,7 @@ function constraint_ohms_yt_to_damage(pm::_PM.AbstractPowerModel, i::Int; nw::In
     # TODO make indexing of :wi,:wr standardized
     ## Because :wi, :wr are indexed by bus_id or bus_pairs depending on if the value is on_off or
     # standard, there are indexing issues.  Temporary solution: always call *_on_off variant
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
         vad_min = _PM.ref(pm, nw, :off_angmin)
         vad_max = _PM.ref(pm, nw, :off_angmax)
 
@@ -161,7 +161,7 @@ function constraint_voltage_angle_difference_damage(pm::_PM.AbstractPowerModel, 
     # TODO make indexing of :wi,:wr standardized
     # Because :wi, :wr are indexed by bus_id or bus_pairs depending on if the value is on_off or
     # standard, there are indexing issues.  Temporary solution: always call *_on_off variant
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
 
         vad_min = _PM.ref(pm, nw, :off_angmin)
         vad_max = _PM.ref(pm, nw, :off_angmax)
@@ -190,7 +190,7 @@ function constraint_thermal_limit_from_damage(pm::_PM.AbstractPowerModel, i::Int
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
         _PM.constraint_thermal_limit_from_on_off(pm, nw, i, f_idx, branch["rate_a"])
     else
         if !haskey(_PM.con(pm, nw), :sm_fr)
@@ -208,7 +208,7 @@ function constraint_thermal_limit_to_damage(pm::_PM.AbstractPowerModel, i::Int; 
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
         _PM.constraint_thermal_limit_to_on_off(pm, nw, i, t_idx, branch["rate_a"])
     else
         if !haskey(_PM.con(pm, nw), :sm_to)
@@ -223,8 +223,8 @@ end
 function constraint_storage_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     storage = _PM.ref(pm, nw, :storage, i)
 
-    storage_damaged = haskey(_PM.ref(pm, nw, :damaged_storage), i)
-    bus_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), storage["storage_bus"])
+    storage_damaged = haskey(_PM.ref(pm, nw, :storage_damage), i)
+    bus_damaged = haskey(_PM.ref(pm, nw, :bus_damage), storage["storage_bus"])
 
 
     if storage_damaged

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -248,18 +248,18 @@ function constraint_storage_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=p
 end
 
 ""
-function constraint_voltage_violation_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
+function constraint_bus_damage_soft(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     bus = _PM.ref(pm, nw, :bus, i)
 
-    constraint_voltage_violation_damage(pm, nw, i, bus["vmin"], bus["vmax"])
+    constraint_bus_damage_soft(pm, nw, i, bus["vmin"], bus["vmax"])
 end
 
 
 ""
-function constraint_bus_voltage_violation(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
+function constraint_voltage_magnitude_bounds_soft(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     bus = _PM.ref(pm, nw, :bus, i)
 
-    constraint_bus_voltage_violation(pm, nw, i, bus["vmin"], bus["vmax"])
+    constraint_voltage_magnitude_bounds_soft(pm, nw, i, bus["vmin"], bus["vmax"])
 end
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -22,14 +22,14 @@ end
 
 
 ""
-function constraint_generation_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
+function constraint_gen_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     gen = _PM.ref(pm, nw, :gen, i)
 
     gen_damaged = haskey(_PM.ref(pm, nw, :damaged_gen), i)
     bus_damaged = haskey(_PM.ref(pm, nw, :damaged_bus), gen["gen_bus"])
 
     if gen_damaged
-        _PM.constraint_generation_on_off(pm, nw, i, gen["pmin"], gen["pmax"], gen["qmin"], gen["qmax"])
+        _PM.constraint_gen_power_on_off(pm, nw, i, gen["pmin"], gen["pmax"], gen["qmin"], gen["qmax"])
         if bus_damaged
             constraint_gen_bus_connection(pm, nw, i, gen["gen_bus"])
         end
@@ -248,10 +248,10 @@ function constraint_storage_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=p
 end
 
 ""
-function constraint_bus_voltage_violation_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
+function constraint_voltage_violation_damage(pm::_PM.AbstractPowerModel, i::Int; nw::Int=pm.cnw)
     bus = _PM.ref(pm, nw, :bus, i)
 
-    constraint_bus_voltage_violation_damage(pm, nw, i, bus["vmin"], bus["vmax"])
+    constraint_voltage_violation_damage(pm, nw, i, bus["vmin"], bus["vmax"])
 end
 
 

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -18,9 +18,8 @@ function ref_add_damaged_gens!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any}
                 damaged_gen[i]=gen
             end
         end
-        nw_ref[:damaged_gen] = damaged_gen
+        nw_ref[:gen_damage] = damaged_gen
     end
-    #_PM.ref(pm,:damaged_gen)
 end
 
 ""
@@ -32,7 +31,7 @@ function ref_add_damaged_buses!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any
                 damaged_bus[i]=bus
             end
         end
-        nw_ref[:damaged_bus] = damaged_bus
+        nw_ref[:bus_damage] = damaged_bus
     end
 end
 
@@ -46,7 +45,7 @@ function ref_add_damaged_branches!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:
                 damaged_branch[i]=branch
             end
         end
-        nw_ref[:damaged_branch] = damaged_branch
+        nw_ref[:branch_damage] = damaged_branch
     end
 end
 
@@ -60,6 +59,6 @@ function ref_add_damaged_storage!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:A
                 damaged_storage[i]=storage
             end
         end
-        nw_ref[:damaged_storage] = damaged_storage
+        nw_ref[:storage_damage] = damaged_storage
     end
 end

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -27,7 +27,7 @@ end
 
 
 "variable: `0 <= damage_gen[l] <= 1` for `l` in `gen`es"
-function variable_gen_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_damaged_gen_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
 
     if relax == false
         z_gen_vars = JuMP.@variable(pm.model,

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -27,18 +27,17 @@ end
 
 
 "variable: `0 <= damage_gen[l] <= 1` for `l` in `gen`es"
-function variable_damaged_gen_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
-
+function variable_gen_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_gen_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_gen)],
+            [l in _PM.ids(pm, nw, :gen_damage)],
             base_name="$(nw)_active_gen",
             binary = true,
             start = _PM.comp_start_value(_PM.ref(pm, nw, :gen, l), "gen_damage_start")
         )
     else
         z_gen_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_gen)],
+            [l in _PM.ids(pm, nw, :gen_damage)],
             base_name="$(nw)_active_gen",
             lower_bound = 0,
             upper_bound = 1,
@@ -113,17 +112,17 @@ end
 
 
 "variable: `0 <= damage_branch[l] <= 1` for `l` in `branch`es"
-function variable_damaged_branch_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_branch_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_branch_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_branch)],
+            [l in _PM.ids(pm, nw, :branch_damage)],
             base_name="$(nw)_active_branch",
             binary = true,
             start = _PM.comp_start_value(_PM.ref(pm, nw, :branch, l), "branch_damage_start")
         )
     else
         z_branch_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_branch)],
+            [l in _PM.ids(pm, nw, :branch_damage)],
             base_name="$(nw)_active_branch",
             lower_bound = 0,
             upper_bound = 1,
@@ -139,17 +138,17 @@ end
 
 
 "variable: `0 <= damage_storage[l] <= 1` for `l` in `storage`es"
-function variable_damaged_storage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_storage_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_storage_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_storage)],
+            [l in _PM.ids(pm, nw, :storage_damage)],
             base_name="$(nw)_active_storage",
             binary = true,
             start = _PM.comp_start_value(_PM.ref(pm, nw, :storage, l), "storage_damage_start")
         )
     else
         z_storage_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_storage)],
+            [l in _PM.ids(pm, nw, :storage_damage)],
             base_name="$(nw)_active_storage",
             lower_bound = 0,
             upper_bound = 1,
@@ -246,17 +245,17 @@ end
 
 
 "variable: `0 <= damage_bus[l] <= 1` for `l` in `bus`es"
-function variable_damaged_bus_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_bus_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_bus_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_bus)],
+            [l in _PM.ids(pm, nw, :bus_damage)],
             base_name="$(nw)_active_bus",
             binary = true,
             start = _PM.comp_start_value(_PM.ref(pm, nw, :bus, l), "bus_damage_start")
         )
     else
         z_bus_vars = JuMP.@variable(pm.model,
-            [l in _PM.ids(pm, nw, :damaged_bus)],
+            [l in _PM.ids(pm, nw, :bus_damage)],
             base_name="$(nw)_active_bus",
             lower_bound = 0,
             upper_bound = 1,

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -2,7 +2,7 @@
 function JuMP.value(x::Real) return x end
 
 "variable: `v[i]` for `i` in `bus`es"
-function variable_voltage_magnitude_on_off(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
+function variable_bus_voltage_magnitude_on_off(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
     vm = _PM.var(pm, nw)[:vm] = JuMP.@variable(pm.model,
         [i in _PM.ids(pm, nw, :bus)], base_name="$(nw)_vm",
         lower_bound = 0.0,
@@ -14,7 +14,7 @@ function variable_voltage_magnitude_on_off(pm::_PM.AbstractPowerModel; nw::Int=p
 end
 
 "variable: `v[i]` for `i` in `bus`es"
-function variable_voltage_magnitude_violation(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
+function variable_bus_voltage_magnitude_violation(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
     vm_vio = _PM.var(pm, nw)[:vm_vio] = JuMP.@variable(pm.model,
         [i in _PM.ids(pm, nw, :bus)], base_name="$(nw)_vm_vio",
         lower_bound = 0.0,
@@ -27,7 +27,7 @@ end
 
 
 "variable: `0 <= damage_gen[l] <= 1` for `l` in `gen`es"
-function variable_generation_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_gen_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
 
     if relax == false
         z_gen_vars = JuMP.@variable(pm.model,
@@ -53,14 +53,14 @@ end
 
 
 "generates variables for both `active` and `reactive` generation"
-function variable_generation_damage(pm::_PM.AbstractPowerModel; kwargs...)
-    variable_active_generation_damage(pm; kwargs...)
-    variable_reactive_generation_damage(pm; kwargs...)
+function variable_gen_power_damage(pm::_PM.AbstractPowerModel; kwargs...)
+    variable_gen_power_real_damage(pm; kwargs...)
+    variable_gen_power_imaginary_damage(pm; kwargs...)
 end
 
 
 "variable: `pg[j]` for `j` in `gen`"
-function variable_active_generation_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
+function variable_gen_power_real_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
     if bounded
         pg = _PM.var(pm, nw)[:pg] = JuMP.@variable(pm.model,
             [i in _PM.ids(pm, nw, :gen)], base_name="$(nw)_pg_dmg",
@@ -86,7 +86,7 @@ end
 
 
 "variable: `qq[j]` for `j` in `gen`"
-function variable_reactive_generation_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
+function variable_gen_power_imaginary_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
     if bounded
         qg = _PM.var(pm, nw)[:qg] = JuMP.@variable(pm.model,
             [i in _PM.ids(pm, nw, :gen)], base_name="$(nw)_qg_dmg",
@@ -113,7 +113,7 @@ end
 
 
 "variable: `0 <= damage_branch[l] <= 1` for `l` in `branch`es"
-function variable_branch_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_damaged_branch_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_branch_vars = JuMP.@variable(pm.model,
             [l in _PM.ids(pm, nw, :damaged_branch)],
@@ -139,7 +139,7 @@ end
 
 
 "variable: `0 <= damage_storage[l] <= 1` for `l` in `storage`es"
-function variable_storage_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_damaged_storage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_storage_vars = JuMP.@variable(pm.model,
             [l in _PM.ids(pm, nw, :damaged_storage)],
@@ -165,10 +165,10 @@ end
 
 
 ""
-function variable_storage_mi_damage(pm::_PM.AbstractPowerModel; kwargs...)
-    variable_active_storage_damage(pm; kwargs...)
-    variable_reactive_storage_damage(pm; kwargs...)
-    variable_current_storage_damage(pm; kwargs...)
+function variable_storage_power_mi_damage(pm::_PM.AbstractPowerModel; kwargs...)
+    variable_storage_power_real_damage(pm; kwargs...)
+    variable_storage_power_imaginary_damage(pm; kwargs...)
+    variable_storage_current_damage(pm; kwargs...)
     _PM.variable_storage_energy(pm; kwargs...)
     _PM.variable_storage_charge(pm; kwargs...)
     _PM.variable_storage_discharge(pm; kwargs...)
@@ -177,11 +177,11 @@ end
 
 
 "do nothing by default but some formulations require this"
-function variable_current_storage_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
+function variable_storage_current_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
 end
 
 ""
-function variable_active_storage_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
+function variable_storage_power_real_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
     inj_lb, inj_ub = _PM.ref_calc_storage_injection_bounds(_PM.ref(pm, nw, :storage), _PM.ref(pm, nw, :bus))
 
     ps = _PM.var(pm, nw)[:ps] = JuMP.@variable(pm.model,
@@ -203,7 +203,7 @@ end
 
 
 ""
-function variable_reactive_storage_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
+function variable_storage_power_imaginary_damage(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
     inj_lb, inj_ub = _PM.ref_calc_storage_injection_bounds(_PM.ref(pm, nw, :storage), _PM.ref(pm, nw, :bus))
 
     qs = _PM.var(pm, nw)[:qs] = JuMP.@variable(pm.model,
@@ -224,7 +224,7 @@ end
 
 
 "variable: `0 <= damage_bus[l] <= 1` for `l` in `bus`es"
-function variable_bus_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_damaged_bus_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == false
         z_bus_vars = JuMP.@variable(pm.model,
             [l in _PM.ids(pm, nw, :damaged_bus)],
@@ -249,46 +249,6 @@ function variable_bus_damage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cn
 end
 
 
-
-
-
-# ""
-# function variable_demand_factor(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax = false)
-#     if relax == true
-#         _PM.var(pm, nw)[:z_demand] = JuMP.@variable(pm.model,
-#             [i in _PM.ids(pm, nw, :load)], base_name="$(nw)_z_demand",
-#             upper_bound = 1,
-#             lower_bound = 0,
-#             start = _PM.comp_start_value(_PM.ref(pm, nw, :load, i), "z_demand_on_start", 1.0)
-#         )
-#     else
-#         _PM.var(pm, nw)[:z_demand] = JuMP.@variable(pm.model,
-#         [i in _PM.ids(pm, nw, :load)], base_name="$(nw)_z_demand",
-#         binary = true,
-#         start = _PM.comp_start_value(_PM.ref(pm, nw, :load, i), "z_demand_on_start", 1.0)
-#     )
-#     end
-# end
-
-
-# ""
-# function variable_shunt_factor(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax = false)
-#     if relax == true
-#         _PM.var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-#             [i in _PM.ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt",
-#             upper_bound = 1,
-#             lower_bound = 0,
-#             start = _PM.comp_start_value(_PM.ref(pm, nw, :shunt, i), "z_shunt_on_start", 1.0)
-#         )
-#     else
-#         _PM.var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-#             [i in _PM.ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt",
-#             binary = true,
-#             start = _PM.comp_start_value(_PM.ref(pm, nw, :shunt, i), "z_shunt_on_start", 1.0)
-#         )
-#     end
-# end
-
 function variable_bus_voltage_indicator(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if !relax
         z_voltage = _PM.var(pm, nw)[:z_voltage] = JuMP.@variable(pm.model,
@@ -310,7 +270,7 @@ end
 
 
 ""
-function variable_voltage_magnitude_sqr_on_off(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
+function variable_bus_voltage_magnitude_sqr_on_off(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw, report::Bool=true)
     w = _PM.var(pm, nw)[:w] = JuMP.@variable(pm.model,
         [i in _PM.ids(pm, nw, :bus)], base_name="$(nw)_w",
         lower_bound = 0,

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -3,14 +3,14 @@ function constraint_model_voltage_damage(pm::_PM.AbstractACPModel, n::Int)
 end
 
 ""
-function variable_voltage_damage(pm::_PM.AbstractACPModel; kwargs...)
-    _PM.variable_voltage_angle(pm; kwargs...)
-    variable_voltage_magnitude_on_off(pm; kwargs...)
-    variable_voltage_magnitude_violation(pm; kwargs...)
+function variable_bus_voltage_damage(pm::_PM.AbstractACPModel; kwargs...)
+    _PM.variable_bus_voltage_angle(pm; kwargs...)
+    variable_bus_voltage_magnitude_on_off(pm; kwargs...)
+    variable_bus_voltage_magnitude_violation(pm; kwargs...)
 end
 
 ""
-function constraint_bus_voltage_violation_damage(pm::_PM.AbstractACPModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_voltage_violation_damage(pm::_PM.AbstractACPModel, n::Int, i::Int, vm_min, vm_max)
     vm = _PM.var(pm, n, :vm, i)
     vm_vio = _PM.var(pm, n, :vm_vio, i)
     z = _PM.var(pm, n, :z_bus, i)
@@ -29,8 +29,8 @@ function constraint_bus_voltage_violation(pm::_PM.AbstractACPModel, n::Int, i::I
 end
 
 function variable_bus_voltage_on_off(pm::_PM.AbstractACPModel; kwargs...)
-    _PM.variable_voltage_angle(pm; kwargs...)
-    variable_voltage_magnitude_on_off(pm; kwargs...)
+    _PM.variable_bus_voltage_angle(pm; kwargs...)
+    variable_bus_voltage_magnitude_on_off(pm; kwargs...)
 end
 
 function constraint_bus_voltage_on_off(pm::_PM.AbstractACPModel; nw::Int=pm.cnw, kwargs...)

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -10,7 +10,7 @@ function variable_bus_voltage_damage(pm::_PM.AbstractACPModel; kwargs...)
 end
 
 ""
-function constraint_voltage_violation_damage(pm::_PM.AbstractACPModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_bus_damage_soft(pm::_PM.AbstractACPModel, n::Int, i::Int, vm_min, vm_max)
     vm = _PM.var(pm, n, :vm, i)
     vm_vio = _PM.var(pm, n, :vm_vio, i)
     z = _PM.var(pm, n, :z_bus, i)
@@ -20,7 +20,7 @@ function constraint_voltage_violation_damage(pm::_PM.AbstractACPModel, n::Int, i
 end
 
 ""
-function constraint_bus_voltage_violation(pm::_PM.AbstractACPModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_voltage_magnitude_bounds_soft(pm::_PM.AbstractACPModel, n::Int, i::Int, vm_min, vm_max)
     vm = _PM.var(pm, n, :vm, i)
     vm_vio = _PM.var(pm, n, :vm_vio, i)
 

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -1,9 +1,9 @@
 
 
 "apo models ignore reactive power flows"
-function variable_reactive_generation_damage(pm::_PM.AbstractActivePowerModel; kwargs...)
+function variable_gen_power_imaginary_damage(pm::_PM.AbstractActivePowerModel; kwargs...)
 end
 
 "apo models ignore reactive power flows"
-function variable_reactive_storage_damage(pm::_PM.AbstractActivePowerModel; kwargs...)
+function variable_storage_power_imaginary_damage(pm::_PM.AbstractActivePowerModel; kwargs...)
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -119,9 +119,9 @@ end
 
 ### These are needed to overload the default behavior for reactive power ###
 "no vm values to turn off"
-function constraint_voltage_violation_damage(pm::_PM.AbstractDCPModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_bus_damage_soft(pm::_PM.AbstractDCPModel, n::Int, i::Int, vm_min, vm_max)
 end
 
 "no vm values to turn off"
-function constraint_bus_voltage_violation(pm::_PM.AbstractDCPModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_voltage_magnitude_bounds_soft(pm::_PM.AbstractDCPModel, n::Int, i::Int, vm_min, vm_max)
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -2,8 +2,8 @@ function constraint_model_voltage_damage(pm::_PM.AbstractDCPModel, n::Int)
 end
 
 ""
-function variable_voltage_damage(pm::_PM.AbstractDCPModel; kwargs...)
-    _PM.variable_voltage_angle(pm; kwargs...)
+function variable_bus_voltage_damage(pm::_PM.AbstractDCPModel; kwargs...)
+    _PM.variable_bus_voltage_angle(pm; kwargs...)
 end
 
 # "no vm values to turn off"
@@ -18,11 +18,11 @@ function variable_bus_voltage_indicator(pm::_PM.AbstractDCPModel; nw::Int=pm.cnw
 end
 
 function variable_bus_voltage_on_off(pm::_PM.AbstractDCPModel; kwargs...)
-    _PM.variable_voltage_angle(pm; kwargs...)
-    variable_voltage_magnitude_on_off(pm; kwargs...)
+    _PM.variable_bus_voltage_angle(pm; kwargs...)
+    variable_bus_voltage_magnitude_on_off(pm; kwargs...)
 end
 
-function variable_voltage_magnitude_on_off(pm::_PM.AbstractDCPModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
+function variable_bus_voltage_magnitude_on_off(pm::_PM.AbstractDCPModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     report && _IM.sol_component_fixed(pm, nw, :bus, :vm, _PM.ids(pm, nw, :bus), 1.0)
 end
 
@@ -119,7 +119,7 @@ end
 
 ### These are needed to overload the default behavior for reactive power ###
 "no vm values to turn off"
-function constraint_bus_voltage_violation_damage(pm::_PM.AbstractDCPModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_voltage_violation_damage(pm::_PM.AbstractDCPModel, n::Int, i::Int, vm_min, vm_max)
 end
 
 "no vm values to turn off"

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -1,30 +1,4 @@
 
-# # same as AbstractWRForm
-""
-function variable_shunt_factor(pm::_PM.AbstractWModels; nw::Int=pm.cnw, relax = false)
-    if relax == true
-        _PM.var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-            [i in _PM.ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt", 
-            upper_bound = 1, 
-            lower_bound = 0,
-            start = _PM.comp_start_value(_PM.ref(pm, nw, :shunt, i), "z_shunt_on_start", 1.0)
-        )
-    else
-        _PM.var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-            [i in _PM.ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt", 
-            binary = true,
-            start = _PM.comp_start_value(_PM.ref(pm, nw, :shunt, i), "z_shunt_on_start", 1.0)
-        )
-    end
-    _PM.var(pm, nw)[:wz_shunt] = JuMP.@variable(pm.model,
-            [i in _PM.ids(pm, nw, :shunt)], base_name="$(nw)_wz_shunt",
-            lower_bound = 0,
-            upper_bound = _PM.ref(pm, nw, :bus)[_PM.ref(pm, nw, :shunt, i)["shunt_bus"]]["vmax"]^2,
-            start = _PM.comp_start_value(_PM.ref(pm, nw, :shunt, i), "wz_shunt_start", 1.001)
-        )
-end
-
-
 ""
 function constraint_power_balance_shed(pm::_PM.AbstractWModels, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w   = _PM.var(pm, n, :w, i)

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -1,16 +1,16 @@
 ""
-function variable_voltage_damage(pm::_PM.AbstractWRModel; kwargs...)
-    variable_voltage_magnitude_sqr_on_off(pm; kwargs...)
-    variable_voltage_magnitude_sqr_violation(pm; kwargs...)
-    _PM.variable_voltage_magnitude_sqr_from_on_off(pm; kwargs...)
-    _PM.variable_voltage_magnitude_sqr_to_on_off(pm; kwargs...)
+function variable_bus_voltage_damage(pm::_PM.AbstractWRModel; kwargs...)
+    variable_bus_voltage_magnitude_sqr_on_off(pm; kwargs...)
+    variable_bus_voltage_magnitude_sqr_violation(pm; kwargs...)
+    _PM.variable_branch_voltage_magnitude_fr_sqr_on_off(pm; kwargs...)
+    _PM.variable_branch_voltage_magnitude_to_sqr_on_off(pm; kwargs...)
 
-    _PM.variable_voltage_product_on_off(pm; kwargs...)
+    _PM.variable_branch_voltage_product_on_off(pm; kwargs...)
 end
 
 "this is the same as non-damaged version becouse ccms includes zero"
-function variable_current_storage_damage(pm::_PM.AbstractWRModel; nw::Int=pm.cnw)
-    _PM.variable_current_storage(pm, nw=nw)
+function variable_storage_current_damage(pm::_PM.AbstractWRModel; nw::Int=pm.cnw)
+    _PM.variable_storage_current(pm, nw=nw)
     # buses = _PM.ref(pm, nw, :bus)
     # ub = Dict()
     # for (i, storage) in _PM.ref(pm, nw, :storage)
@@ -32,7 +32,7 @@ end
 
 
 ""
-function variable_voltage_magnitude_sqr_violation(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw)
+function variable_bus_voltage_magnitude_sqr_violation(pm::_PM.AbstractPowerModel; nw::Int=pm.cnw)
     _PM.var(pm, nw)[:w_vio] = JuMP.@variable(pm.model,
         [i in _PM.ids(pm, nw, :bus)], base_name="$(nw)_w_vio",
         lower_bound = 0.0,
@@ -108,7 +108,7 @@ end
 
 
 ""
-function constraint_bus_voltage_violation_damage(pm::_PM.AbstractWRModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_voltage_violation_damage(pm::_PM.AbstractWRModel, n::Int, i::Int, vm_min, vm_max)
     w = _PM.var(pm, n, :w, i)
     w_vio = _PM.var(pm, n, :w_vio, i)
     z = _PM.var(pm, n, :z_bus, i)
@@ -215,7 +215,7 @@ end
 
 
 function variable_bus_voltage_on_off(pm::_PM.AbstractWRModel; kwargs...)
-    variable_voltage_magnitude_sqr_on_off(pm; kwargs...)
+    variable_bus_voltage_magnitude_sqr_on_off(pm; kwargs...)
     variable_bus_voltage_product_on_off(pm; kwargs...)
 end
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -108,7 +108,7 @@ end
 
 
 ""
-function constraint_voltage_violation_damage(pm::_PM.AbstractWRModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_bus_damage_soft(pm::_PM.AbstractWRModel, n::Int, i::Int, vm_min, vm_max)
     w = _PM.var(pm, n, :w, i)
     w_vio = _PM.var(pm, n, :w_vio, i)
     z = _PM.var(pm, n, :z_bus, i)
@@ -118,7 +118,7 @@ function constraint_voltage_violation_damage(pm::_PM.AbstractWRModel, n::Int, i:
 end
 
 ""
-function constraint_bus_voltage_violation(pm::_PM.AbstractWRModel, n::Int, i::Int, vm_min, vm_max)
+function constraint_voltage_magnitude_bounds_soft(pm::_PM.AbstractWRModel, n::Int, i::Int, vm_min, vm_max)
     w = _PM.var(pm, n, :w, i)
     w_vio = _PM.var(pm, n, :w_vio, i)
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -167,7 +167,7 @@ function constraint_ohms_yt_from_damage(pm::_PM.AbstractWRModel, i::Int; nw::Int
     # TODO make indexing of :wi,:wr standardized
     ## Because :wi, :wr are indexed by bus_id or bus_pairs depending on if the value is on_off or
     # standard, there are indexing issues.  Temporary solution: always call *_on_off variant
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
         vad_min = _PM.ref(pm, nw, :off_angmin)
         vad_max = _PM.ref(pm, nw, :off_angmax)
         _PM.constraint_ohms_yt_from_on_off(pm, nw, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
@@ -197,7 +197,7 @@ function constraint_ohms_yt_to_damage(pm::_PM.AbstractWRModel, i::Int; nw::Int=p
     # TODO make indexing of :wi,:wr standardized
     ## Because :wi, :wr are indexed by bus_id or bus_pairs depending on if the value is on_off or
     # standard, there are indexing issues.  Temporary solution: always call *_on_off variant
-    if haskey(_PM.ref(pm, nw, :damaged_branch), i)
+    if haskey(_PM.ref(pm, nw, :branch_damage), i)
         vad_min = _PM.ref(pm, nw, :off_angmin)
         vad_max = _PM.ref(pm, nw, :off_angmax)
 

--- a/src/prob/mld.jl
+++ b/src/prob/mld.jl
@@ -7,26 +7,27 @@ function build_mld(pm::_PM.AbstractPowerModel)
     variable_bus_voltage_indicator(pm, relax=true)
     variable_bus_voltage_on_off(pm)
 
-    _PM.variable_generation_indicator(pm, relax=true)
-    _PM.variable_generation_on_off(pm)
+    _PM.variable_gen_indicator(pm, relax=true)
+    _PM.variable_gen_power_on_off(pm)
 
-    _PM.variable_branch_flow(pm)
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm)
 
-    _PM.variable_demand_factor(pm, relax=true)
-    _PM.variable_shunt_factor(pm, relax=true)
+    _PM.variable_load_power_factor(pm, relax=true)
+    _PM.variable_shunt_admittance_factor(pm, relax=true)
 
 
     objective_max_loadability(pm)
 
 
+    constraint_bus_voltage_on_off(pm)
+
     for i in _PM.ids(pm, :ref_buses)
         _PM.constraint_theta_ref(pm, i)
     end
-    constraint_bus_voltage_on_off(pm)
 
     for i in _PM.ids(pm, :gen)
-        _PM.constraint_generation_on_off(pm, i)
+        _PM.constraint_gen_power_on_off(pm, i)
     end
 
     for i in _PM.ids(pm, :bus)
@@ -44,7 +45,7 @@ function build_mld(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :dcline)
-        _PM.constraint_dcline(pm, i)
+        _PM.constraint_dcline_power_losses(pm, i)
     end
 end
 
@@ -60,27 +61,27 @@ function build_mld_uc(pm::_PM.AbstractPowerModel)
     variable_bus_voltage_indicator(pm)
     variable_bus_voltage_on_off(pm)
 
-    _PM.variable_generation_indicator(pm)
-    _PM.variable_generation_on_off(pm)
+    _PM.variable_gen_indicator(pm)
+    _PM.variable_gen_power_on_off(pm)
 
-    _PM.variable_branch_flow(pm)
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm)
 
-    _PM.variable_demand_factor(pm, relax=true)
-    _PM.variable_shunt_factor(pm, relax=true)
+    _PM.variable_load_power_factor(pm, relax=true)
+    _PM.variable_shunt_admittance_factor(pm, relax=true)
 
 
     objective_max_loadability(pm)
 
 
+    constraint_bus_voltage_on_off(pm)
+
     for i in _PM.ids(pm, :ref_buses)
         _PM.constraint_theta_ref(pm, i)
     end
-    constraint_bus_voltage_on_off(pm)
-
 
     for i in _PM.ids(pm, :gen)
-        _PM.constraint_generation_on_off(pm, i)
+        _PM.constraint_gen_power_on_off(pm, i)
     end
 
     for i in _PM.ids(pm, :bus)
@@ -98,7 +99,7 @@ function build_mld_uc(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :dcline)
-        _PM.constraint_dcline(pm, i)
+        _PM.constraint_dcline_power_losses(pm, i)
     end
 end
 
@@ -109,14 +110,14 @@ function run_mld_smpl(file, model_constructor, solver; kwargs...)
 end
 
 function run_mld_smpl(pm::_PM.AbstractPowerModel)
-    _PM.variable_voltage(pm, bounded = false)
-    _PM.variable_generation(pm, bounded = false)
+    _PM.variable_bus_voltage(pm, bounded = false)
+    _PM.variable_gen_power(pm, bounded = false)
 
-    _PM.variable_branch_flow(pm)
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm)
 
-    _PM.variable_demand_factor(pm, relax=true)
-    _PM.variable_shunt_factor(pm, relax=true)
+    _PM.variable_load_power_factor(pm, relax=true)
+    _PM.variable_shunt_admittance_factor(pm, relax=true)
 
     _PM.var(pm)[:vm_vio] = JuMP.@variable(pm.model, vm_vio[i in _PM.ids(pm, :bus)] >= 0)
     _PM.var(pm)[:pg_vio] = JuMP.@variable(pm.model, pg_vio[i in _PM.ids(pm, :gen)] >= 0)
@@ -137,11 +138,11 @@ function run_mld_smpl(pm::_PM.AbstractPowerModel)
         sum( load_weight[i]*abs(load["pd"])*z_demand[i] for (i, load) in _PM.ref(pm, :load))
     )
 
+    _PM.constraint_model_voltage(pm)
+
     for i in _PM.ids(pm, :ref_buses)
         _PM.constraint_theta_ref(pm, i)
     end
-
-    _PM.constraint_model_voltage(pm)
 
     for (i, bus) in _PM.ref(pm, :bus)
         constraint_power_balance_shed(pm, i)
@@ -179,29 +180,30 @@ function build_mld_strg(pm::_PM.AbstractPowerModel)
     variable_bus_voltage_indicator(pm, relax=true)
     variable_bus_voltage_on_off(pm)
 
-    _PM.variable_generation_indicator(pm, relax=true)
-    _PM.variable_generation_on_off(pm)
+    _PM.variable_gen_indicator(pm, relax=true)
+    _PM.variable_gen_power_on_off(pm)
 
     _PM.variable_storage_indicator(pm, relax = true)
-    _PM.variable_storage_mi_on_off(pm)
+    _PM.variable_storage_power_mi_on_off(pm)
 
-    _PM.variable_branch_flow(pm)
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm)
 
-    _PM.variable_demand_factor(pm, relax=true)
-    _PM.variable_shunt_factor(pm, relax=true)
+    _PM.variable_load_power_factor(pm, relax=true)
+    _PM.variable_shunt_admittance_factor(pm, relax=true)
 
 
     objective_max_loadability_strg(pm)
 
 
+    constraint_bus_voltage_on_off(pm)
+
     for i in _PM.ids(pm, :ref_buses)
         _PM.constraint_theta_ref(pm, i)
     end
-    constraint_bus_voltage_on_off(pm)
 
     for i in _PM.ids(pm, :gen)
-        _PM.constraint_generation_on_off(pm, i)
+        _PM.constraint_gen_power_on_off(pm, i)
     end
 
     for i in _PM.ids(pm, :bus)
@@ -212,7 +214,7 @@ function build_mld_strg(pm::_PM.AbstractPowerModel)
         _PM.constraint_storage_state(pm, i)
         _PM.constraint_storage_complementarity_mi(pm, i)
         _PM.constraint_storage_on_off(pm,i)
-        _PM.constraint_storage_loss(pm, i)
+        _PM.constraint_storage_losses(pm, i)
         _PM.constraint_storage_thermal_limit(pm, i)
     end
 
@@ -227,7 +229,7 @@ function build_mld_strg(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :dcline)
-        _PM.constraint_dcline(pm, i)
+        _PM.constraint_dcline_power_losses(pm, i)
     end
 end
 
@@ -240,29 +242,30 @@ function build_mld_strg_uc(pm::_PM.AbstractPowerModel)
     variable_bus_voltage_indicator(pm, relax=true)
     variable_bus_voltage_on_off(pm)
 
-    _PM.variable_generation_indicator(pm)
-    _PM.variable_generation_on_off(pm)
+    _PM.variable_gen_indicator(pm)
+    _PM.variable_gen_power_on_off(pm)
 
     _PM.variable_storage_indicator(pm)
-    _PM.variable_storage_mi_on_off(pm)
+    _PM.variable_storage_power_mi_on_off(pm)
 
-    _PM.variable_branch_flow(pm)
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm)
 
-    _PM.variable_demand_factor(pm, relax=true)
-    _PM.variable_shunt_factor(pm, relax=true)
+    _PM.variable_load_power_factor(pm, relax=true)
+    _PM.variable_shunt_admittance_factor(pm, relax=true)
 
 
     objective_max_loadability_strg(pm)
 
 
+    constraint_bus_voltage_on_off(pm)
+
     for i in _PM.ids(pm, :ref_buses)
         _PM.constraint_theta_ref(pm, i)
     end
-    constraint_bus_voltage_on_off(pm)
 
     for i in _PM.ids(pm, :gen)
-        _PM.constraint_generation_on_off(pm, i)
+        _PM.constraint_gen_power_on_off(pm, i)
     end
 
     for i in _PM.ids(pm, :bus)
@@ -272,7 +275,7 @@ function build_mld_strg_uc(pm::_PM.AbstractPowerModel)
     for i in _PM.ids(pm, :storage)
         _PM.constraint_storage_state(pm, i)
         _PM.constraint_storage_complementarity_mi(pm, i)
-        _PM.constraint_storage_loss(pm, i)
+        _PM.constraint_storage_losses(pm, i)
         _PM.constraint_storage_thermal_limit(pm, i)
         _PM.constraint_storage_on_off(pm,i)
     end
@@ -288,7 +291,7 @@ function build_mld_strg_uc(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :dcline)
-        _PM.constraint_dcline(pm, i)
+        _PM.constraint_dcline_power_losses(pm, i)
     end
 end
 

--- a/src/prob/mrsp.jl
+++ b/src/prob/mrsp.jl
@@ -7,18 +7,18 @@ end
 
 ""
 function build_mrsp(pm::_PM.AbstractPowerModel)
-    variable_damaged_bus_indicator(pm)
+    variable_bus_damage_indicator(pm)
     variable_bus_voltage_damage(pm)
 
-    variable_damaged_branch_indicator(pm)
+    variable_branch_damage_indicator(pm)
     _PM.variable_branch_power(pm)
 
     _PM.variable_dcline_power(pm)
 
-    variable_damaged_storage_indicator(pm)
+    variable_storage_damage_indicator(pm)
     variable_storage_power_mi_damage(pm)
 
-    variable_damaged_gen_indicator(pm)
+    variable_gen_damage_indicator(pm)
     variable_gen_power_damage(pm)
 
     _PM.constraint_model_voltage_on_off(pm)
@@ -71,10 +71,10 @@ function objective_min_restoration(pm::_PM.AbstractPowerModel)
     z_bus = _PM.var(pm, pm.cnw, :z_bus)
 
     JuMP.@objective(pm.model, Min,
-        sum(z_branch[i] for (i,branch) in _PM.ref(pm, :damaged_branch))
-        + sum(z_gen[i] for (i,gen) in _PM.ref(pm, :damaged_gen))
-        + sum(z_storage[i] for (i,storage) in _PM.ref(pm, :damaged_storage))
-        + sum(z_bus[i] for (i,bus) in _PM.ref(pm, :damaged_bus))
+        sum(z_branch[i] for (i,branch) in _PM.ref(pm, :branch_damage))
+        + sum(z_gen[i] for (i,gen) in _PM.ref(pm, :gen_damage))
+        + sum(z_storage[i] for (i,storage) in _PM.ref(pm, :storage_damage))
+        + sum(z_bus[i] for (i,bus) in _PM.ref(pm, :bus_damage))
     )
 end
 

--- a/src/prob/mrsp.jl
+++ b/src/prob/mrsp.jl
@@ -18,7 +18,7 @@ function build_mrsp(pm::_PM.AbstractPowerModel)
     variable_damaged_storage_indicator(pm)
     variable_storage_power_mi_damage(pm)
 
-    variable_gen_damage_indicator(pm)
+    variable_damaged_gen_indicator(pm)
     variable_gen_power_damage(pm)
 
     _PM.constraint_model_voltage_on_off(pm)

--- a/src/prob/mrsp.jl
+++ b/src/prob/mrsp.jl
@@ -7,19 +7,19 @@ end
 
 ""
 function build_mrsp(pm::_PM.AbstractPowerModel)
-    variable_bus_damage_indicator(pm)
-    variable_voltage_damage(pm)
+    variable_damaged_bus_indicator(pm)
+    variable_bus_voltage_damage(pm)
 
-    variable_branch_damage_indicator(pm)
-    _PM.variable_branch_flow(pm)
+    variable_damaged_branch_indicator(pm)
+    _PM.variable_branch_power(pm)
 
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_dcline_power(pm)
 
-    variable_storage_damage_indicator(pm)
-    variable_storage_mi_damage(pm)
+    variable_damaged_storage_indicator(pm)
+    variable_storage_power_mi_damage(pm)
 
-    variable_generation_damage_indicator(pm)
-    variable_generation_damage(pm)
+    variable_gen_damage_indicator(pm)
+    variable_gen_power_damage(pm)
 
     _PM.constraint_model_voltage_on_off(pm)
 
@@ -28,12 +28,12 @@ function build_mrsp(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :bus)
-        constraint_bus_voltage_violation_damage(pm, i)
+        constraint_voltage_violation_damage(pm, i)
         _PM.constraint_power_balance(pm, i)
     end
 
     for i in _PM.ids(pm, :gen)
-        constraint_generation_damage(pm, i)
+        constraint_gen_damage(pm, i)
     end
 
     for i in _PM.ids(pm, :branch)
@@ -48,14 +48,14 @@ function build_mrsp(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :dcline)
-        _PM.constraint_dcline(pm, i)
+        _PM.constraint_dcline_power_losses(pm, i)
     end
 
     for i in _PM.ids(pm, :storage)
         constraint_storage_damage(pm, i)
         _PM.constraint_storage_state(pm, i)
         _PM.constraint_storage_complementarity_mi(pm, i)
-        _PM.constraint_storage_loss(pm, i)
+        _PM.constraint_storage_losses(pm, i)
     end
 
     objective_min_restoration(pm)

--- a/src/prob/mrsp.jl
+++ b/src/prob/mrsp.jl
@@ -28,7 +28,7 @@ function build_mrsp(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :bus)
-        constraint_voltage_violation_damage(pm, i)
+        constraint_bus_damage_soft(pm, i)
         _PM.constraint_power_balance(pm, i)
     end
 

--- a/src/prob/rop.jl
+++ b/src/prob/rop.jl
@@ -8,22 +8,22 @@ end
 ""
 function build_rop(pm::_PM.AbstractPowerModel)
     for (n, network) in _PM.nws(pm)
-        variable_bus_damage_indicator(pm, nw=n)
-        variable_voltage_damage(pm, nw=n)
+        variable_damaged_bus_indicator(pm, nw=n)
+        variable_bus_voltage_damage(pm, nw=n)
 
-        variable_branch_damage_indicator(pm, nw=n)
-        _PM.variable_branch_flow(pm, nw=n)
+        variable_damaged_branch_indicator(pm, nw=n)
+        _PM.variable_branch_power(pm, nw=n)
 
-        _PM.variable_dcline_flow(pm, nw=n)
+        _PM.variable_dcline_power(pm, nw=n)
 
-        variable_storage_damage_indicator(pm, nw=n)
-        variable_storage_mi_damage(pm, nw=n)
+        variable_damaged_storage_indicator(pm, nw=n)
+        variable_storage_power_mi_damage(pm, nw=n)
 
-        variable_generation_damage_indicator(pm, nw=n)
-        variable_generation_damage(pm, nw=n)
+        variable_gen_damage_indicator(pm, nw=n)
+        variable_gen_power_damage(pm, nw=n)
 
-        _PM.variable_demand_factor(pm, nw=n, relax=true)
-        _PM.variable_shunt_factor(pm, nw=n, relax=true)
+        _PM.variable_load_power_factor(pm, nw=n, relax=true)
+        _PM.variable_shunt_admittance_factor(pm, nw=n, relax=true)
 
         constraint_restoration_cardinality_ub(pm, nw=n)
 
@@ -34,12 +34,12 @@ function build_rop(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :bus, nw=n)
-            constraint_bus_voltage_violation_damage(pm, i, nw=n)
+            constraint_voltage_violation_damage(pm, i, nw=n)
             constraint_power_balance_shed(pm, i, nw=n)
         end
 
         for i in _PM.ids(pm, :gen, nw=n)
-            constraint_generation_damage(pm, i, nw=n)
+            constraint_gen_damage(pm, i, nw=n)
         end
 
         for i in _PM.ids(pm, :load, nw=n)
@@ -62,13 +62,13 @@ function build_rop(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :dcline, nw=n)
-            _PM.constraint_dcline(pm, i, nw=n)
+            _PM.constraint_dcline_power_losses(pm, i, nw=n)
         end
 
         for i in _PM.ids(pm, :storage, nw=n)
             constraint_storage_damage(pm, i, nw=n)
             _PM.constraint_storage_complementarity_mi(pm, i, nw=n)
-            _PM.constraint_storage_loss(pm, i, nw=n)
+            _PM.constraint_storage_losses(pm, i, nw=n)
         end
     end
 
@@ -84,19 +84,19 @@ function build_rop(pm::_PM.AbstractPowerModel)
             _PM.constraint_storage_state(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :gen, nw=n_2)
-            constraint_active_gen(pm, i, n_1, n_2)
+            constraint_gen_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :bus, nw=n_2)
-            constraint_active_bus(pm, i, n_1, n_2)
+            constraint_bus_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :storage, nw=n_2)
-            constraint_active_storage(pm, i, n_1, n_2)
+            constraint_storage_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :branch, nw=n_2)
-            constraint_active_branch(pm, i, n_1, n_2)
+            constraint_branch_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :load, nw=n_2)
-            constraint_increasing_load(pm, i, n_1, n_2)
+            constraint_load_increasing(pm, i, n_1, n_2)
         end
         n_1 = n_2
     end

--- a/src/prob/rop.jl
+++ b/src/prob/rop.jl
@@ -84,16 +84,16 @@ function build_rop(pm::_PM.AbstractPowerModel)
             _PM.constraint_storage_state(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :gen, nw=n_2)
-            constraint_gen_active(pm, i, n_1, n_2)
+            constraint_gen_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :bus, nw=n_2)
-            constraint_bus_active(pm, i, n_1, n_2)
+            constraint_bus_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :storage, nw=n_2)
-            constraint_storage_active(pm, i, n_1, n_2)
+            constraint_storage_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :branch, nw=n_2)
-            constraint_branch_active(pm, i, n_1, n_2)
+            constraint_branch_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :load, nw=n_2)
             constraint_load_increasing(pm, i, n_1, n_2)

--- a/src/prob/rop.jl
+++ b/src/prob/rop.jl
@@ -34,7 +34,7 @@ function build_rop(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :bus, nw=n)
-            constraint_voltage_violation_damage(pm, i, nw=n)
+            constraint_bus_damage_soft(pm, i, nw=n)
             constraint_power_balance_shed(pm, i, nw=n)
         end
 

--- a/src/prob/rop.jl
+++ b/src/prob/rop.jl
@@ -19,7 +19,7 @@ function build_rop(pm::_PM.AbstractPowerModel)
         variable_damaged_storage_indicator(pm, nw=n)
         variable_storage_power_mi_damage(pm, nw=n)
 
-        variable_gen_damage_indicator(pm, nw=n)
+        variable_damaged_gen_indicator(pm, nw=n)
         variable_gen_power_damage(pm, nw=n)
 
         _PM.variable_load_power_factor(pm, nw=n, relax=true)

--- a/src/prob/rop.jl
+++ b/src/prob/rop.jl
@@ -8,18 +8,18 @@ end
 ""
 function build_rop(pm::_PM.AbstractPowerModel)
     for (n, network) in _PM.nws(pm)
-        variable_damaged_bus_indicator(pm, nw=n)
+        variable_bus_damage_indicator(pm, nw=n)
         variable_bus_voltage_damage(pm, nw=n)
 
-        variable_damaged_branch_indicator(pm, nw=n)
+        variable_branch_damage_indicator(pm, nw=n)
         _PM.variable_branch_power(pm, nw=n)
 
         _PM.variable_dcline_power(pm, nw=n)
 
-        variable_damaged_storage_indicator(pm, nw=n)
+        variable_storage_damage_indicator(pm, nw=n)
         variable_storage_power_mi_damage(pm, nw=n)
 
-        variable_damaged_gen_indicator(pm, nw=n)
+        variable_gen_damage_indicator(pm, nw=n)
         variable_gen_power_damage(pm, nw=n)
 
         _PM.variable_load_power_factor(pm, nw=n, relax=true)

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -7,28 +7,29 @@ function _build_mld_discrete_load(pm::_PM.AbstractPowerModel)
     variable_bus_voltage_indicator(pm)
     variable_bus_voltage_on_off(pm)
 
-    _PM.variable_generation_indicator(pm)
-    _PM.variable_generation_on_off(pm)
+    _PM.variable_gen_indicator(pm)
+    _PM.variable_gen_power_on_off(pm)
 
-    _PM.variable_storage(pm)
+    _PM.variable_storage_power(pm)
 
-    _PM.variable_branch_flow(pm)
-    _PM.variable_dcline_flow(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm)
 
-    _PM.variable_demand_factor(pm)
-    _PM.variable_shunt_factor(pm)
+    _PM.variable_load_power_factor(pm)
+    _PM.variable_shunt_admittance_factor(pm)
 
 
     objective_max_loadability(pm)
 
 
+    constraint_bus_voltage_on_off(pm)
+
     for i in _PM.ids(pm, :ref_buses)
         _PM.constraint_theta_ref(pm, i)
     end
-    constraint_bus_voltage_on_off(pm)
 
     for i in _PM.ids(pm, :gen)
-        _PM.constraint_generation_on_off(pm, i)
+        _PM.constraint_gen_power_on_off(pm, i)
     end
 
     for i in _PM.ids(pm, :bus)
@@ -46,6 +47,6 @@ function _build_mld_discrete_load(pm::_PM.AbstractPowerModel)
     end
 
     for i in _PM.ids(pm, :dcline)
-        _PM.constraint_dcline(pm, i)
+        _PM.constraint_dcline_power_losses(pm, i)
     end
 end

--- a/src/util/iterative_restoration.jl
+++ b/src/util/iterative_restoration.jl
@@ -206,22 +206,22 @@ end
 ""
 function _build_rop_ir(pm::_PM.AbstractPowerModel)
     for (n, network) in _PM.nws(pm)
-        variable_bus_damage_indicator(pm, nw=n)
-        variable_voltage_damage(pm, nw=n)
+        variable_damaged_bus_indicator(pm, nw=n)
+        variable_bus_voltage_damage(pm, nw=n)
 
-        variable_branch_damage_indicator(pm, nw=n)
-        _PM.variable_branch_flow(pm, nw=n)
+        variable_damaged_branch_indicator(pm, nw=n)
+        _PM.variable_branch_power(pm, nw=n)
 
-        _PM.variable_dcline_flow(pm, nw=n)
+        _PM.variable_dcline_power(pm, nw=n)
 
-        variable_storage_damage_indicator(pm, nw=n)
-        variable_storage_mi_damage(pm, nw=n)
+        variable_damaged_storage_indicator(pm, nw=n)
+        variable_storage_power_mi_damage(pm, nw=n)
 
-        variable_generation_damage_indicator(pm, nw=n)
-        variable_generation_damage(pm, nw=n)
+        variable_gen_damage_indicator(pm, nw=n)
+        variable_gen_power_damage(pm, nw=n)
 
-        _PM.variable_demand_factor(pm, nw=n, relax=true)
-        _PM.variable_shunt_factor(pm, nw=n, relax=true)
+        _PM.variable_load_power_factor(pm, nw=n, relax=true)
+        _PM.variable_shunt_admittance_factor(pm, nw=n, relax=true)
 
         constraint_restoration_cardinality_ub(pm, nw=n)
         constraint_restoration_cardinality_lb(pm, nw=n)
@@ -233,12 +233,12 @@ function _build_rop_ir(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :bus, nw=n)
-            constraint_bus_voltage_violation_damage(pm, i, nw=n)
+            constraint_voltage_violation_damage(pm, i, nw=n)
             constraint_power_balance_shed(pm, i, nw=n)
         end
 
         for i in _PM.ids(pm, :gen, nw=n)
-            constraint_generation_damage(pm, i, nw=n)
+            constraint_gen_damage(pm, i, nw=n)
         end
 
         for i in _PM.ids(pm, :load, nw=n)
@@ -261,13 +261,13 @@ function _build_rop_ir(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :dcline, nw=n)
-            _PM.constraint_dcline(pm, i, nw=n)
+            _PM.constraint_dcline_power_losses(pm, i, nw=n)
         end
 
         for i in _PM.ids(pm, :storage, nw=n)
             constraint_storage_damage(pm, i, nw=n)
             _PM.constraint_storage_complementarity_mi(pm, i, nw=n)
-            _PM.constraint_storage_loss(pm, i, nw=n)
+            _PM.constraint_storage_losses(pm, i, nw=n)
         end
     end
 
@@ -283,19 +283,19 @@ function _build_rop_ir(pm::_PM.AbstractPowerModel)
             _PM.constraint_storage_state(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :gen, nw=n_2)
-            constraint_active_gen(pm, i, n_1, n_2)
+            constraint_gen_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :bus, nw=n_2)
-            constraint_active_bus(pm, i, n_1, n_2)
+            constraint_bus_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :storage, nw=n_2)
-            constraint_active_storage(pm, i, n_1, n_2)
+            constraint_storage_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :branch, nw=n_2)
-            constraint_active_branch(pm, i, n_1, n_2)
+            constraint_branch_active(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :load, nw=n_2)
-            constraint_increasing_load(pm, i, n_1, n_2)
+            constraint_load_increasing(pm, i, n_1, n_2)
         end
         n_1 = n_2
     end

--- a/src/util/iterative_restoration.jl
+++ b/src/util/iterative_restoration.jl
@@ -233,7 +233,7 @@ function _build_rop_ir(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :bus, nw=n)
-            constraint_voltage_violation_damage(pm, i, nw=n)
+            constraint_bus_damage_soft(pm, i, nw=n)
             constraint_power_balance_shed(pm, i, nw=n)
         end
 

--- a/src/util/iterative_restoration.jl
+++ b/src/util/iterative_restoration.jl
@@ -283,16 +283,16 @@ function _build_rop_ir(pm::_PM.AbstractPowerModel)
             _PM.constraint_storage_state(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :gen, nw=n_2)
-            constraint_gen_active(pm, i, n_1, n_2)
+            constraint_gen_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :bus, nw=n_2)
-            constraint_bus_active(pm, i, n_1, n_2)
+            constraint_bus_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :storage, nw=n_2)
-            constraint_storage_active(pm, i, n_1, n_2)
+            constraint_storage_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :branch, nw=n_2)
-            constraint_branch_active(pm, i, n_1, n_2)
+            constraint_branch_energized(pm, i, n_1, n_2)
         end
         for i in _PM.ids(pm, :load, nw=n_2)
             constraint_load_increasing(pm, i, n_1, n_2)

--- a/src/util/iterative_restoration.jl
+++ b/src/util/iterative_restoration.jl
@@ -206,18 +206,18 @@ end
 ""
 function _build_rop_ir(pm::_PM.AbstractPowerModel)
     for (n, network) in _PM.nws(pm)
-        variable_damaged_bus_indicator(pm, nw=n)
+        variable_bus_damage_indicator(pm, nw=n)
         variable_bus_voltage_damage(pm, nw=n)
 
-        variable_damaged_branch_indicator(pm, nw=n)
+        variable_branch_damage_indicator(pm, nw=n)
         _PM.variable_branch_power(pm, nw=n)
 
         _PM.variable_dcline_power(pm, nw=n)
 
-        variable_damaged_storage_indicator(pm, nw=n)
+        variable_storage_damage_indicator(pm, nw=n)
         variable_storage_power_mi_damage(pm, nw=n)
 
-        variable_damaged_gen_indicator(pm, nw=n)
+        variable_gen_damage_indicator(pm, nw=n)
         variable_gen_power_damage(pm, nw=n)
 
         _PM.variable_load_power_factor(pm, nw=n, relax=true)
@@ -312,16 +312,16 @@ function constraint_restore_all_items_partial_load(pm, n)
     z_branch = _PM.var(pm, n, :z_branch)
     z_bus = _PM.var(pm, n, :z_bus)
 
-    for (i,storage) in  _PM.ref(pm, n, :damaged_storage)
+    for (i,storage) in  _PM.ref(pm, n, :storage_damage)
         JuMP.@constraint(pm.model, z_storage[i] == 1)
     end
-    for (i,gen) in  _PM.ref(pm, n, :damaged_gen)
+    for (i,gen) in  _PM.ref(pm, n, :gen_damage)
         JuMP.@constraint(pm.model, z_gen[i] == 1)
     end
-    for (i,branch) in  _PM.ref(pm, n, :damaged_branch)
+    for (i,branch) in  _PM.ref(pm, n, :branch_damage)
         JuMP.@constraint(pm.model, z_branch[i] == 1)
     end
-    for (i,bus) in  _PM.ref(pm, n, :damaged_bus)
+    for (i,bus) in  _PM.ref(pm, n, :bus_damage)
         JuMP.@constraint(pm.model, z_bus[i] == 1)
     end
 end

--- a/src/util/iterative_restoration.jl
+++ b/src/util/iterative_restoration.jl
@@ -217,7 +217,7 @@ function _build_rop_ir(pm::_PM.AbstractPowerModel)
         variable_damaged_storage_indicator(pm, nw=n)
         variable_storage_power_mi_damage(pm, nw=n)
 
-        variable_gen_damage_indicator(pm, nw=n)
+        variable_damaged_gen_indicator(pm, nw=n)
         variable_gen_power_damage(pm, nw=n)
 
         _PM.variable_load_power_factor(pm, nw=n, relax=true)

--- a/src/util/restoration_redispatch.jl
+++ b/src/util/restoration_redispatch.jl
@@ -15,16 +15,16 @@ end
 ""
 function build_restoration_redispatch(pm::_PM.AbstractPowerModel)
     for (n, network) in _PM.nws(pm)
-        _PM.variable_voltage(pm, nw=n)
-        variable_voltage_magnitude_violation(pm; nw=n)
+        _PM.variable_bus_voltage(pm, nw=n)
+        variable_bus_voltage_magnitude_violation(pm; nw=n)
 
-        _PM.variable_generation(pm, nw=n)
-        _PM.variable_storage(pm, nw=n)
-        _PM.variable_branch_flow(pm, nw=n)
-        _PM.variable_dcline_flow(pm, nw=n)
+        _PM.variable_gen_power(pm, nw=n)
+        _PM.variable_storage_power(pm, nw=n)
+        _PM.variable_branch_power(pm, nw=n)
+        _PM.variable_dcline_power(pm, nw=n)
 
-        _PM.variable_demand_factor(pm, nw=n, relax=true)
-        _PM.variable_shunt_factor(pm, nw=n, relax=true)
+        _PM.variable_load_power_factor(pm, nw=n, relax=true)
+        _PM.variable_shunt_admittance_factor(pm, nw=n, relax=true)
 
         _PM.constraint_model_voltage(pm, nw=n)
 
@@ -39,7 +39,7 @@ function build_restoration_redispatch(pm::_PM.AbstractPowerModel)
 
         for i in _PM.ids(pm, :storage, nw=n)
             _PM.constraint_storage_complementarity_nl(pm, i, nw=n)
-            _PM.constraint_storage_loss(pm, i, nw=n)
+            _PM.constraint_storage_losses(pm, i, nw=n)
             _PM.constraint_storage_thermal_limit(pm, i, nw=n)
         end
 
@@ -54,7 +54,7 @@ function build_restoration_redispatch(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :dcline, nw=n)
-            _PM.constraint_dcline(pm, i, nw=n)
+            _PM.constraint_dcline_power_losses(pm, i, nw=n)
         end
 
     end

--- a/src/util/restoration_redispatch.jl
+++ b/src/util/restoration_redispatch.jl
@@ -33,7 +33,7 @@ function build_restoration_redispatch(pm::_PM.AbstractPowerModel)
         end
 
         for i in _PM.ids(pm, :bus, nw=n)
-            constraint_bus_voltage_violation(pm, i, nw=n)
+            constraint_voltage_magnitude_bounds_soft(pm, i, nw=n)
             constraint_power_balance_shed(pm, i, nw=n)
         end
 

--- a/test/mld_strg.jl
+++ b/test/mld_strg.jl
@@ -35,9 +35,9 @@
 
         #println(result["objective"])
         @test result["termination_status"] == LOCALLY_SOLVED
-        @test isapprox(result["objective"], 2080.1068,; atol = 1e-2)
+        @test isapprox(result["objective"], 2080.2286; atol = 1e-2)
         #println("active power: $(active_power_served(result))")
-        @test isapprox(active_power_served(result), 0.10708; atol = 1e-1)
+        @test isapprox(active_power_served(result), 0.22888; atol = 1e-1)
         @test !haskey(result["solution"],"gen") # all generators are inactive
         @test isapprox(storage_status(result, "1"), 1.000000; atol = 1e-6)
         @test isapprox(storage_status(result, "2"), 1.000000; atol = 1e-6)
@@ -63,7 +63,7 @@ end
 
         #println(result["objective"])
         @test result["termination_status"] == LOCALLY_SOLVED
-        @test isapprox(result["objective"], 2304.98; atol = 1e-2)
+        @test isapprox(result["objective"], 2305.94; atol = 1e-2)
         #println("active power: $(active_power_served(result))")
         @test isapprox(active_power_served(result), 6.9476; atol = 1e-1)
         @test isapprox(gen_status(result, "1"), 1.000000; atol = 1e-6)
@@ -80,9 +80,9 @@ end
 
         #println(result["objective"])
         @test result["termination_status"] == LOCALLY_SOLVED
-        @test isapprox(result["objective"], 2080.11,; atol = 1e-2)
+        @test isapprox(result["objective"], 2080.22; atol = 1e-2)
         #println("active power: $(active_power_served(result))")
-        @test isapprox(active_power_served(result), 0.10708; atol = 1e-1)
+        @test isapprox(active_power_served(result), 0.228540; atol = 1e-1)
         @test !haskey(result["solution"],"gen") # all generators are inactive
         @test isapprox(storage_status(result, "1"), 1.000000; atol = 1e-6)
         @test isapprox(storage_status(result, "2"), 1.000000; atol = 1e-6)

--- a/test/mrsp.jl
+++ b/test/mrsp.jl
@@ -191,7 +191,7 @@
 
             # required due to oscillation between semantical solutions
             gen_status_total = sum(gen_status(result, id) for id in ["1", "2", "3", "4", "5"])
-            @test isapprox(gen_status_total, 2; atol=1e-2)
+            @test 1.99 <= gen_status_total && gen_status_total <= 3.01
 
             # @test isapprox(gen_status(result,"1"), 0; atol=1e-2)
             # @test isapprox(gen_status(result,"2"), 1; atol=1e-2)

--- a/test/mrsp.jl
+++ b/test/mrsp.jl
@@ -191,7 +191,7 @@
 
             # required due to oscillation between semantical solutions
             gen_status_total = sum(gen_status(result, id) for id in ["1", "2", "3", "4", "5"])
-            @test isapprox(gen_status_total, 3; atol=1e-2)
+            @test isapprox(gen_status_total, 2; atol=1e-2)
 
             # @test isapprox(gen_status(result,"1"), 0; atol=1e-2)
             # @test isapprox(gen_status(result,"2"), 1; atol=1e-2)
@@ -204,7 +204,7 @@
 
             # required due to oscillation between semantical solutions
             branch_status_total = sum(branch_status(result, id) for id in ["1", "2", "3", "4", "5", "6", "7"])
-            @test isapprox(branch_status_total, 3; atol=1e-2)
+            @test isapprox(branch_status_total, 4; atol=1e-2)
 
             # @test isapprox(branch_status(result,"1"), 1; atol=1e-2)
             # @test isapprox(branch_status(result,"2"), 1; atol=1e-2)

--- a/test/mrsp.jl
+++ b/test/mrsp.jl
@@ -204,7 +204,7 @@
 
             # required due to oscillation between semantical solutions
             branch_status_total = sum(branch_status(result, id) for id in ["1", "2", "3", "4", "5", "6", "7"])
-            @test isapprox(branch_status_total, 4; atol=1e-2)
+            @test 2.99 <= branch_status_total && branch_status_total <= 4.01
 
             # @test isapprox(branch_status(result,"1"), 1; atol=1e-2)
             # @test isapprox(branch_status(result,"2"), 1; atol=1e-2)


### PR DESCRIPTION
The CI will fail becouse PM v0.17 is not yet tagged but it is working locally for me.  Thought I would setup the PR so you could have at least 12 hours to review the proposed name updates @pseudocubic and @noahrhodes.

In review the PR I also noticed that we need a new name for the `active` constraints as that term is now reserved for real power values.