### PR TITLE
Add option to solve MLD for disconnected components

### DIFF
--- a/src/util/ac-mld-uc.jl
+++ b/src/util/ac-mld-uc.jl
@@ -5,7 +5,7 @@ function run_ac_mld_uc(
     modifications::Dict{String,<:Any}=Dict{String,Any}("per_unit" => case["per_unit"]),
     setting::Dict{String,<:Any}=Dict{String,Any}(),
     int_tol::Real=1e-6,
-    restore_disconnected_subnetworks::Bool=false,
+    include_disconnected_subnetworks::Bool=false,
 )
     base_case = case
     case = deepcopy(case)

--- a/src/util/ac-mld-uc.jl
+++ b/src/util/ac-mld-uc.jl
@@ -1,4 +1,3 @@
-
 "implements a scalable heuristic solution to the AC-MLD problem"
 function run_ac_mld_uc(
     case::Dict{String,<:Any},

--- a/src/util/ac-mld-uc.jl
+++ b/src/util/ac-mld-uc.jl
@@ -5,7 +5,7 @@ function run_ac_mld_uc(
     modifications::Dict{String,<:Any}=Dict{String,Any}("per_unit" => case["per_unit"]),
     setting::Dict{String,<:Any}=Dict{String,Any}(),
     int_tol::Real=1e-6,
-    largest_component_only::Bool=true,
+    restore_disconnected_subnetworks::Bool=false,
 )
     base_case = case
     case = deepcopy(case)
@@ -14,10 +14,10 @@ function run_ac_mld_uc(
     # Note that this can hide some load shed if a connected component with
     # load but no generation is created.
     _PM.simplify_network!(case)
-    if largest_component_only
-        _PM.select_largest_component!(case)
-    else
+    if restore_disconnected_subnetworks
         _PM.correct_reference_buses!(case)
+    else
+        _PM.select_largest_component!(case)
     end
 
     if length(setting) != 0
@@ -66,10 +66,10 @@ function run_ac_mld_uc(
     if bus_count <= 0
         result = soc_result
     else
-        if largest_component_only
-            _PM.select_largest_component!(case)
-        else
+        if restore_disconnected_subnetworks
             _PM.correct_reference_buses!(case)
+        else
+            _PM.select_largest_component!(case)
         end
 
         # MLD with gen and bus participation fixed, and generation/voltage bounds

--- a/src/util/ac-mld-uc.jl
+++ b/src/util/ac-mld-uc.jl
@@ -1,21 +1,37 @@
 
-"implements a scalable huristic solution to the AC-MLD problem"
-function run_ac_mld_uc(case::Dict{String,<:Any}, solver; modifications::Dict{String,<:Any}=Dict{String,Any}("per_unit" => case["per_unit"]), setting::Dict{String,<:Any}=Dict{String,Any}(), int_tol::Real=1e-6)
+"implements a scalable heuristic solution to the AC-MLD problem"
+function run_ac_mld_uc(
+    case::Dict{String,<:Any},
+    solver;
+    modifications::Dict{String,<:Any}=Dict{String,Any}("per_unit" => case["per_unit"]),
+    setting::Dict{String,<:Any}=Dict{String,Any}(),
+    int_tol::Real=1e-6,
+    largest_component_only::Bool=true,
+)
     base_case = case
     case = deepcopy(case)
     _PM.update_data!(case, modifications)
 
+    # Note that this can hide some load shed if a connected component with
+    # load but no generation is created.
     _PM.simplify_network!(case)
-    _PM.select_largest_component!(case)
-    #_PM.correct_refrence_buses!(case)
+    if largest_component_only
+        _PM.select_largest_component!(case)
+    else
+        _PM.correct_reference_buses!(case)
+    end
 
     if length(setting) != 0
         Memento.info(_PM._LOGGER, "settings: $(setting)")
     end
 
-
+    # Run MLD with SOC relaxation. This gives us an upper bound on load delivery for any
+    # feasible solution to our original problem. I.e., the contingency will always be
+    # at least this bad.
     soc_result = run_mld(case, _PM.SOCWRPowerModel, solver; setting=setting)
 
+    # Check termination_status instead of primal_status here as, without optimality,
+    # the relaxation solution loses its meaning.
     @assert (soc_result["termination_status"] == _PM.LOCALLY_SOLVED || soc_result["termination_status"] == _PM.OPTIMAL)
     soc_sol = soc_result["solution"]
 
@@ -24,6 +40,12 @@ function run_ac_mld_uc(case::Dict{String,<:Any}, solver; modifications::Dict{Str
     Memento.info(_PM._LOGGER, "soc active gen:    $(soc_active_output)")
     Memento.info(_PM._LOGGER, "soc active demand: $(soc_active_delivered)")
 
+    # Round down bus and generator statuses from SOC solution and propagate to
+    # case data. I.e., if the optimistic solution doesn't have a bus/gen "all the
+    # way on", we deactivate that device.
+    # This is a heuristic to help us get feasible solutions later. (We also
+    # relax bounds to *ensure* we get a feasible solution, but this helps us
+    # not violate bounds.)
     for (i,bus) in soc_sol["bus"]
         if case["bus"][i]["bus_type"] != 4 && bus["status"] <= 1-int_tol
             case["bus"][i]["bus_type"] = 4
@@ -45,8 +67,14 @@ function run_ac_mld_uc(case::Dict{String,<:Any}, solver; modifications::Dict{Str
     if bus_count <= 0
         result = soc_result
     else
-        _PM.select_largest_component!(case)
+        if largest_component_only
+            _PM.select_largest_component!(case)
+        else
+            _PM.correct_reference_buses!(case)
+        end
 
+        # MLD with gen and bus participation fixed, and generation/voltage bounds
+        # relaxed (and penalized)
         ac_result = run_mld_smpl(case, _PM.ACPPowerModel, solver; setting=setting)
         ac_result["solve_time"] = ac_result["solve_time"] + soc_result["solve_time"]
 
@@ -56,7 +84,9 @@ function run_ac_mld_uc(case::Dict{String,<:Any}, solver; modifications::Dict{Str
         result = ac_result
     end
 
-
+    # Propagate statuses of deactivated components back to solution. These
+    # components were deactivated by rounding the SOC solution by subsequent
+    # simplification steps.
     sol = result["solution"]
     for (i,bus) in base_case["bus"]
         if bus["bus_type"] != 4 && case["bus"][i]["bus_type"] == 4

--- a/src/util/ac-mld-uc.jl
+++ b/src/util/ac-mld-uc.jl
@@ -5,7 +5,7 @@ function run_ac_mld_uc(
     modifications::Dict{String,<:Any}=Dict{String,Any}("per_unit" => case["per_unit"]),
     setting::Dict{String,<:Any}=Dict{String,Any}(),
     int_tol::Real=1e-6,
-    include_disconnected_subnetworks::Bool=false,
+    optimize_disconnected_subnetworks::Bool=false,
 )
     base_case = case
     case = deepcopy(case)
@@ -14,7 +14,7 @@ function run_ac_mld_uc(
     # Note that this can hide some load shed if a connected component with
     # load but no generation is created.
     _PM.simplify_network!(case)
-    if restore_disconnected_subnetworks
+    if optimize_disconnected_subnetworks
         _PM.correct_reference_buses!(case)
     else
         _PM.select_largest_component!(case)
@@ -66,7 +66,7 @@ function run_ac_mld_uc(
     if bus_count <= 0
         result = soc_result
     else
-        if restore_disconnected_subnetworks
+        if optimize_disconnected_subnetworks
             _PM.correct_reference_buses!(case)
         else
             _PM.select_largest_component!(case)

--- a/test/util.jl
+++ b/test/util.jl
@@ -106,7 +106,7 @@
         orig_pd_served = sum(l -> l["pd"]*l["status"], values(orig_sol["load"]))
         @test isapprox(orig_pd_served, 2.70; atol = 1e-1)
 
-        result = run_ac_mld_uc(data, nlp_solver; largest_component_only = false)
+        result = run_ac_mld_uc(data, nlp_solver; restore_disconnected_subnetworks = true)
         @test isapprox(result["objective"], 9.29; atol = 1e-1)
         sol = result["solution"]
         pd_served = sum(l -> l["pd"]*l["status"], values(sol["load"]))

--- a/test/util.jl
+++ b/test/util.jl
@@ -106,7 +106,7 @@
         orig_pd_served = sum(l -> l["pd"]*l["status"], values(orig_sol["load"]))
         @test isapprox(orig_pd_served, 2.70; atol = 1e-1)
 
-        result = run_ac_mld_uc(data, nlp_solver; include_disconnected_subnetworks = true)
+        result = run_ac_mld_uc(data, nlp_solver; optimize_disconnected_subnetworks = true)
         @test isapprox(result["objective"], 9.29; atol = 1e-1)
         sol = result["solution"]
         pd_served = sum(l -> l["pd"]*l["status"], values(sol["load"]))

--- a/test/util.jl
+++ b/test/util.jl
@@ -106,7 +106,7 @@
         orig_pd_served = sum(l -> l["pd"]*l["status"], values(orig_sol["load"]))
         @test isapprox(orig_pd_served, 2.70; atol = 1e-1)
 
-        result = run_ac_mld_uc(data, nlp_solver; restore_disconnected_subnetworks = true)
+        result = run_ac_mld_uc(data, nlp_solver; include_disconnected_subnetworks = true)
         @test isapprox(result["objective"], 9.29; atol = 1e-1)
         sol = result["solution"]
         pd_served = sum(l -> l["pd"]*l["status"], values(sol["load"]))

--- a/test/util.jl
+++ b/test/util.jl
@@ -75,6 +75,49 @@
         @test all_gens_on(result)
         @test all_voltages_on(result)
     end
+    @testset "5-bus disconnected case" begin
+        data = deepcopy(case5_pti)
+        bus_ids = collect(keys(data["bus"]))
+        orig_ccs = PowerModels.calc_connected_components(data)
+        orig_ref_buses = filter(i -> data["bus"][i]["bus_type"] == 3, bus_ids)
+        @test length(orig_ref_buses) == 1
+        @test length(orig_ccs) == 1
+
+        # Island bus 3, which has two loads and one generator
+        data["branch"]["4"]["br_status"] = 0
+        data["branch"]["6"]["br_status"] = 0
+        data["branch"]["7"]["br_status"] = 0
+
+        # Activate generator on bus 3
+        data["gen"]["3"]["gen_status"] = 1
+        # Increase demand so it can't be met by the generator
+        data["load"]["3"]["pd"] = 5.0 # Increased from 1
+
+        PowerModels.correct_reference_buses!(data)
+        ccs = PowerModels.calc_connected_components(data)
+        ref_buses = filter(i -> data["bus"][i]["bus_type"] == 3, bus_ids)
+        @test length(ccs) == 2
+        @test length(ref_buses) == 2
+
+        # Default only uses the largest connected component
+        orig_result = run_ac_mld_uc(data, nlp_solver)
+        @test isapprox(orig_result["objective"], 4.09; atol = 1e-1)
+        orig_sol = orig_result["solution"]
+        orig_pd_served = sum(l -> l["pd"]*l["status"], values(orig_sol["load"]))
+        @test isapprox(orig_pd_served, 2.70; atol = 1e-1)
+
+        result = run_ac_mld_uc(data, nlp_solver; largest_component_only = false)
+        @test isapprox(result["objective"], 9.29; atol = 1e-1)
+        sol = result["solution"]
+        pd_served = sum(l -> l["pd"]*l["status"], values(sol["load"]))
+        @test isapprox(pd_served, 6.60; atol = 1e-1)
+
+        # Make sure the discrepancy in load served is due to the generator
+        # on the islanded bus.
+        pg3 = result["solution"]["gen"]["3"]["pg"]
+        diff = active_power_served(result) - active_power_served(orig_result)
+        @test isapprox(pg3, diff; atol = 1e-2)
+    end
 end
 
 


### PR DESCRIPTION
`run_ac_mld_uc` processes the network with `select_largest_component!`, meaning that the restoration decisions are not made on smaller subnetworks &mdash; they deactivate all generators/buses and don't meet any of their demand. We can get better restoration decisions (more load delivered) by considering disconnected subnetworks. This PR adds an option, ~~`largest_component_only=true`~~ `restore_disconnected_subnetworks=false` (I'm open to name suggestions), that can be set to make `run_ac_mld_uc` handle disconnected subnetworks.

I also added some comments to `run_ac_mld_uc` to help me remember what it's doing.